### PR TITLE
feat: launchpad CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ workflows:
               ignore:
                 - gh-pages
                 - /launchpad.*/ # TODO: Remove this filter once the branch is merged into development
-      - run-launchpad-tests:
+      - run-launchpad-tests: # TODO: Remove this workflow once the branch is merged into development
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,37 @@ commands:
       - store_artifacts:
           path: integration_tests/temp/reports
 
+  launchpad-ci:
+    description: Run Launchpad-such-wow tests
+    steps:
+      - run:
+          name: node -v
+          command: node -v
+      - run:
+          name: npm -v
+          command: npm -v
+      - run:
+          name: npm install
+          command: cd applications/launchpad_v2 && npm install
+      - run:
+          name: lint
+          command: |
+            cd applications/launchpad_v2
+            npm run lint:test
+          when: always
+      - run:
+          name: test
+          command: |
+            cd applications/launchpad_v2
+            npm run test:ci
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: applications/launchpad_v2/temp/reports/junit
+      - store_test_results:
+          path: applications/launchpad_v2/temp/reports
+      - store_artifacts:
+          path: applications/launchpad_v2/temp/reports
+          destination: launchpad_reports
+
 jobs:
   run-integration-tests:
     docker:
@@ -122,6 +153,15 @@ jobs:
       - checkout
       - cucumber-js-ffi
 
+  run-launchpad-tests:
+    docker:
+      - image: *rust_image
+    environment:
+      CARGO_HTTP_MULTIPLEXING: false
+    steps:
+      - checkout
+      - launchpad-ci
+
 workflows:
   version: 2
   workflow:
@@ -130,12 +170,16 @@ workflows:
           filters:
             branches:
               ignore:
-                gh-pages
-                launchpad_such_wow # TODO: Remove this filter once the branch is merged into development
+                - gh-pages
+                - /launchpad.*/ # TODO: Remove this filter once the branch is merged into development
       - run-ffi-integration-tests:
           filters:
             branches:
               ignore:
-                gh-pages
-                launchpad_such_wow # TODO: Remove this filter once the branch is merged into development
-
+                - gh-pages
+                - /launchpad.*/ # TODO: Remove this filter once the branch is merged into development
+      - run-launchpad-tests:
+          filters:
+            branches:
+              only:
+                - /launchpad.*/

--- a/applications/launchpad_v2/.gitignore
+++ b/applications/launchpad_v2/.gitignore
@@ -7,6 +7,7 @@
 
 # testing
 /coverage
+.jest
 
 # production
 /build
@@ -17,6 +18,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+temp
 
 npm-debug.log*
 yarn-debug.log*

--- a/applications/launchpad_v2/README.md
+++ b/applications/launchpad_v2/README.md
@@ -26,7 +26,7 @@ The Tari Launchpad is dedicated for beginners in Blockchain world, as well as fo
 $ npm install
 
 # Run the application
-$ npm run tauri dev
+$ npm run dev
 ```
 
 ### Other scripts
@@ -38,6 +38,21 @@ $ npm run lint
 
 # With auto-fix
 $ npm run lint:fix
+
+# Run Lint test - it produces report in temp/reports folder
+$ npm run lint:test
+```
+
+#### Tests
+
+```bash
+$ npm run test
+```
+
+#### Build
+
+```bash
+$ npm run bundle
 ```
 
 ## Development notes
@@ -65,3 +80,7 @@ Recommendations:
 - `styles` - Design system
 - `types` - (?) not sure if we need this. It should contain common types used across the application. we keep it for now and remove at the end if not needed.
 - `utils` - helpers etc.
+
+### CI with CircleCI
+
+The CircleCI runs tests and eslint check for branches that name starts with `launchpad`.

--- a/applications/launchpad_v2/__tests__/mocks/mockImages.js
+++ b/applications/launchpad_v2/__tests__/mocks/mockImages.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/applications/launchpad_v2/__tests__/mocks/mockStyles.js
+++ b/applications/launchpad_v2/__tests__/mocks/mockStyles.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/applications/launchpad_v2/jest.config.js
+++ b/applications/launchpad_v2/jest.config.js
@@ -1,0 +1,26 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  globals: {
+    'ts-jest': {
+      isolatedModules: true,
+    },
+  },
+  transform: {
+    '^.+\\.(ts|tsx|js|jsx)$': 'ts-jest',
+  },
+  testPathIgnorePatterns: ['node_modules/', '__tests__/mocks/'],
+  transformIgnorePatterns: ['node_modules/(?!@tauri)'],
+  cacheDirectory: '.jest/cache',
+  moduleNameMapper: {
+    '\\.(svg|png|jpg)$': '<rootDir>/__tests__/mocks/mockImages.js',
+    '\\.(css|scss)$': '<rootDir>/__tests__/mocks/mockStyles.js',
+  },
+  setupFilesAfterEnv: [
+    '<rootDir>/src/setupTests.ts'
+  ],
+  collectCoverage: true,
+  reporters: ['jest-junit'],
+  coverageDirectory: 'temp/reports/tests',
+}

--- a/applications/launchpad_v2/package-lock.json
+++ b/applications/launchpad_v2/package-lock.json
@@ -9,13 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@tauri-apps/api": "^1.0.0-rc.3",
-        "@testing-library/jest-dom": "^5.14.1",
-        "@testing-library/react": "^12.0.0",
-        "@testing-library/user-event": "^13.2.1",
         "@types/jest": "^27.0.1",
         "@types/node": "^16.7.13",
         "@types/react": "^17.0.20",
-        "@types/react-dom": "^17.0.9",
+        "@types/react-dom": "^18.0.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-scripts": "5.0.0",
@@ -25,12 +22,17 @@
       },
       "devDependencies": {
         "@tauri-apps/cli": "^1.0.0-rc.8",
+        "@testing-library/jest-dom": "^5.16.4",
+        "@testing-library/react": "^13.0.1",
+        "@testing-library/user-event": "^14.1.0",
         "@types/styled-components": "^5.1.25",
         "@typescript-eslint/eslint-plugin": "^5.19.0",
         "@typescript-eslint/parser": "^5.19.0",
         "cross-env": "^7.0.3",
         "eslint": "^8.13.0",
-        "eslint-plugin-react": "^7.29.4"
+        "eslint-plugin-react": "^7.29.4",
+        "jest-junit": "^13.1.0",
+        "ts-jest": "^27.1.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2733,6 +2735,7 @@
     },
     "node_modules/@testing-library/dom": {
       "version": "8.13.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -2750,6 +2753,7 @@
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.16.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.9.2",
@@ -2770,6 +2774,7 @@
     },
     "node_modules/@testing-library/jest-dom/node_modules/chalk": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2780,29 +2785,30 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "12.1.5",
-      "license": "MIT",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.1.1.tgz",
+      "integrity": "sha512-8mirlAa0OKaUvnqnZF6MdAh2tReYA2KtWVw1PKvaF5EcCZqgK5pl8iF+3uW90JdG5Ua2c2c2E2wtLdaug3dsVg==",
+      "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "<18.0.0"
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
-        "react": "<18.0.0",
-        "react-dom": "<18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.1.1.tgz",
+      "integrity": "sha512-XrjH/iEUqNl9lF2HX9YhPNV7Amntkcnpw0Bo1KkRzowNDcgSN9i0nm4Q8Oi5wupgdfPaJNMAWa61A+voD6Kmwg==",
+      "dev": true,
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {
@@ -2825,6 +2831,7 @@
     },
     "node_modules/@types/aria-query": {
       "version": "4.2.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -3069,10 +3076,11 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.15",
-      "license": "MIT",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.1.tgz",
+      "integrity": "sha512-jCwTXvHtRLiyVvKm9aEdHXs8rflVOGd5Sl913JZrPshfXjn8NYsTNZOz70bCsA31IR0TOqwi3ad+X4tSCBoMTw==",
       "dependencies": {
-        "@types/react": "^17"
+        "@types/react": "*"
       }
     },
     "node_modules/@types/resolve": {
@@ -3141,6 +3149,7 @@
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/jest": "*"
@@ -3716,6 +3725,7 @@
     },
     "node_modules/aria-query": {
       "version": "5.0.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=6.0"
@@ -3809,6 +3819,7 @@
     },
     "node_modules/atob": {
       "version": "2.1.2",
+      "dev": true,
       "license": "(MIT OR Apache-2.0)",
       "bin": {
         "atob": "bin/atob.js"
@@ -4214,6 +4225,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "dependencies": {
+        "fast-json-stable-stringify": "2.x"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bser": {
@@ -4741,6 +4764,7 @@
     },
     "node_modules/css": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.4",
@@ -4995,6 +5019,7 @@
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cssdb": {
@@ -5154,6 +5179,7 @@
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
@@ -5326,6 +5352,7 @@
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.13",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-converter": {
@@ -7163,6 +7190,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7835,6 +7863,33 @@
     "node_modules/jest-jasmine2/node_modules/@types/node": {
       "version": "17.0.23",
       "license": "MIT"
+    },
+    "node_modules/jest-junit": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-13.1.0.tgz",
+      "integrity": "sha512-ECbhzEG3Oe2IH3Mnwcv2vAXM4qTbcObN/gTUzwKPlpaNsf2G/zlj/teEUqRGV17YQiQ4AqzTf3pCO7W59DKVIw==",
+      "dev": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/jest-junit/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/jest-leak-detector": {
       "version": "27.5.1",
@@ -8536,6 +8591,7 @@
     },
     "node_modules/lz-string": {
       "version": "1.4.4",
+      "dev": true,
       "license": "WTFPL",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -8560,6 +8616,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "node_modules/makeerror": {
       "version": "1.0.12",
@@ -8658,6 +8720,7 @@
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -10773,6 +10836,7 @@
     },
     "node_modules/redent": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -11424,6 +11488,7 @@
     },
     "node_modules/source-map-resolve": {
       "version": "0.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atob": "^2.1.2",
@@ -11626,6 +11691,7 @@
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
@@ -12155,6 +12221,76 @@
     "node_modules/tryer": {
       "version": "1.0.1",
       "license": "MIT"
+    },
+    "node_modules/ts-jest": {
+      "version": "27.1.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.4.tgz",
+      "integrity": "sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==",
+      "dev": true,
+      "dependencies": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^27.0.0",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "bin": {
+        "ts-jest": "cli.js"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.0.0-beta.0 <8",
+        "@types/jest": "^27.0.0",
+        "babel-jest": ">=27.0.0 <28",
+        "jest": "^27.0.0",
+        "typescript": ">=3.8 <5.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@types/jest": {
+          "optional": true
+        },
+        "babel-jest": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-jest/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ts-jest/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.1",
@@ -13101,6 +13237,12 @@
         }
       }
     },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
+    },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
       "license": "Apache-2.0"
@@ -13122,6 +13264,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -14716,6 +14864,7 @@
     },
     "@testing-library/dom": {
       "version": "8.13.0",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -14729,6 +14878,7 @@
     },
     "@testing-library/jest-dom": {
       "version": "5.16.4",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.9.2",
         "@types/testing-library__jest-dom": "^5.9.1",
@@ -14743,6 +14893,7 @@
       "dependencies": {
         "chalk": {
           "version": "3.0.0",
+          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -14751,18 +14902,22 @@
       }
     },
     "@testing-library/react": {
-      "version": "12.1.5",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.1.1.tgz",
+      "integrity": "sha512-8mirlAa0OKaUvnqnZF6MdAh2tReYA2KtWVw1PKvaF5EcCZqgK5pl8iF+3uW90JdG5Ua2c2c2E2wtLdaug3dsVg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "<18.0.0"
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
       }
     },
     "@testing-library/user-event": {
-      "version": "13.5.0",
-      "requires": {
-        "@babel/runtime": "^7.12.5"
-      }
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.1.1.tgz",
+      "integrity": "sha512-XrjH/iEUqNl9lF2HX9YhPNV7Amntkcnpw0Bo1KkRzowNDcgSN9i0nm4Q8Oi5wupgdfPaJNMAWa61A+voD6Kmwg==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2"
@@ -14771,7 +14926,8 @@
       "version": "0.2.0"
     },
     "@types/aria-query": {
-      "version": "4.2.2"
+      "version": "4.2.2",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.19",
@@ -14992,9 +15148,11 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.15",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.1.tgz",
+      "integrity": "sha512-jCwTXvHtRLiyVvKm9aEdHXs8rflVOGd5Sl913JZrPshfXjn8NYsTNZOz70bCsA31IR0TOqwi3ad+X4tSCBoMTw==",
       "requires": {
-        "@types/react": "^17"
+        "@types/react": "*"
       }
     },
     "@types/resolve": {
@@ -15059,6 +15217,7 @@
     },
     "@types/testing-library__jest-dom": {
       "version": "5.14.3",
+      "dev": true,
       "requires": {
         "@types/jest": "*"
       }
@@ -15404,7 +15563,8 @@
       }
     },
     "aria-query": {
-      "version": "5.0.0"
+      "version": "5.0.0",
+      "dev": true
     },
     "array-flatten": {
       "version": "1.1.1"
@@ -15459,7 +15619,8 @@
       "version": "1.0.0"
     },
     "atob": {
-      "version": "2.1.2"
+      "version": "2.1.2",
+      "dev": true
     },
     "autoprefixer": {
       "version": "10.4.4",
@@ -15724,6 +15885,15 @@
         "escalade": "^3.1.1",
         "node-releases": "^2.0.2",
         "picocolors": "^1.0.0"
+      }
+    },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
       }
     },
     "bser": {
@@ -16041,6 +16211,7 @@
     },
     "css": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.4",
         "source-map": "^0.6.1",
@@ -16173,7 +16344,8 @@
       "version": "6.1.0"
     },
     "css.escape": {
-      "version": "1.5.1"
+      "version": "1.5.1",
+      "dev": true
     },
     "cssdb": {
       "version": "6.5.0"
@@ -16276,7 +16448,8 @@
       "version": "10.3.1"
     },
     "decode-uri-component": {
-      "version": "0.2.0"
+      "version": "0.2.0",
+      "dev": true
     },
     "dedent": {
       "version": "0.7.0"
@@ -16377,7 +16550,8 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.5.13"
+      "version": "0.5.13",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -17501,7 +17675,8 @@
       "version": "0.1.4"
     },
     "indent-string": {
-      "version": "4.0.0"
+      "version": "4.0.0",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -17910,6 +18085,26 @@
       "dependencies": {
         "@types/node": {
           "version": "17.0.23"
+        }
+      }
+    },
+    "jest-junit": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-13.1.0.tgz",
+      "integrity": "sha512-ECbhzEG3Oe2IH3Mnwcv2vAXM4qTbcObN/gTUzwKPlpaNsf2G/zlj/teEUqRGV17YQiQ4AqzTf3pCO7W59DKVIw==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^8.3.2",
+        "xml": "^1.0.1"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
         }
       }
     },
@@ -18376,7 +18571,8 @@
       "version": "7.8.1"
     },
     "lz-string": {
-      "version": "1.4.4"
+      "version": "1.4.4",
+      "dev": true
     },
     "magic-string": {
       "version": "0.25.9",
@@ -18389,6 +18585,12 @@
       "requires": {
         "semver": "^6.0.0"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "makeerror": {
       "version": "1.0.12",
@@ -18443,7 +18645,8 @@
       "version": "2.1.0"
     },
     "min-indent": {
-      "version": "1.0.1"
+      "version": "1.0.1",
+      "dev": true
     },
     "mini-css-extract-plugin": {
       "version": "2.6.0",
@@ -19593,6 +19796,7 @@
     },
     "redent": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -19977,6 +20181,7 @@
     },
     "source-map-resolve": {
       "version": "0.6.0",
+      "dev": true,
       "requires": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0"
@@ -20117,6 +20322,7 @@
     },
     "strip-indent": {
       "version": "3.0.0",
+      "dev": true,
       "requires": {
         "min-indent": "^1.0.0"
       }
@@ -20432,6 +20638,42 @@
     },
     "tryer": {
       "version": "1.0.1"
+    },
+    "ts-jest": {
+      "version": "27.1.4",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-27.1.4.tgz",
+      "integrity": "sha512-qjkZlVPWVctAezwsOD1OPzbZ+k7zA5z3oxII4dGdZo5ggX/PL7kvwTM0pXTr10fAtbiVpJaL3bWd502zAhpgSQ==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "fast-json-stable-stringify": "2.x",
+        "jest-util": "^27.0.0",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "20.x"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "tsconfig-paths": {
       "version": "3.14.1",
@@ -21058,6 +21300,12 @@
       "version": "8.5.0",
       "requires": {}
     },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
+    },
     "xml-name-validator": {
       "version": "3.0.0"
     },
@@ -21069,6 +21317,12 @@
     },
     "y18n": {
       "version": "5.0.8"
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yaml": {
       "version": "1.10.2"

--- a/applications/launchpad_v2/package.json
+++ b/applications/launchpad_v2/package.json
@@ -4,13 +4,10 @@
   "private": true,
   "dependencies": {
     "@tauri-apps/api": "^1.0.0-rc.3",
-    "@testing-library/jest-dom": "^5.14.1",
-    "@testing-library/react": "^12.0.0",
-    "@testing-library/user-event": "^13.2.1",
     "@types/jest": "^27.0.1",
     "@types/node": "^16.7.13",
     "@types/react": "^17.0.20",
-    "@types/react-dom": "^17.0.9",
+    "@types/react-dom": "^18.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-scripts": "5.0.0",
@@ -21,17 +18,26 @@
   "scripts": {
     "start": "cross-env BROWSER=none react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "jest --reporters=default --reporters=jest-junit",
+    "test:ci": "jest --ci --runInBand --reporters=default --reporters=jest-junit",
     "eject": "react-scripts eject",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "tauri": "tauri"
+    "lint:test": "mkdir -p temp/reports && eslint . --format junit --output-file temp/reports/launchpad_eslint.xml",
+    "tauri": "tauri",
+    "dev": "tauri dev",
+    "bundle": "tauri build"
   },
   "eslintConfig": {
     "extends": [
       "react-app",
       "react-app/jest"
     ]
+  },
+  "jest-junit": {
+    "outputDirectory": "temp/reports/junit",
+    "outputName": "junit.xml",
+    "uniqueOutputName": "false"
   },
   "browserslist": {
     "production": [
@@ -48,10 +54,15 @@
   "devDependencies": {
     "@tauri-apps/cli": "^1.0.0-rc.8",
     "@types/styled-components": "^5.1.25",
+    "@testing-library/jest-dom": "^5.16.4",
+    "@testing-library/react": "^13.0.1",
+    "@testing-library/user-event": "^14.1.0",
     "@typescript-eslint/eslint-plugin": "^5.19.0",
     "@typescript-eslint/parser": "^5.19.0",
     "cross-env": "^7.0.3",
     "eslint": "^8.13.0",
-    "eslint-plugin-react": "^7.29.4"
+    "eslint-plugin-react": "^7.29.4",
+    "jest-junit": "^13.1.0",
+    "ts-jest": "^27.1.4"
   }
 }

--- a/applications/launchpad_v2/src-tauri/tauri.conf.json
+++ b/applications/launchpad_v2/src-tauri/tauri.conf.json
@@ -6,8 +6,8 @@
   "build": {
     "distDir": "../build",
     "devPath": "http://localhost:3000",
-    "beforeDevCommand": "cd ../ && yarn start",
-    "beforeBuildCommand": "cd ../ && yarn build"
+    "beforeDevCommand": "cd ../ && npm run start",
+    "beforeBuildCommand": "cd ../ && npm run build"
   },
   "tauri": {
     "cli": {
@@ -25,7 +25,7 @@
     "bundle": {
       "active": true,
       "targets": "all",
-      "identifier": "com.tauri.dev",
+      "identifier": "com.tari.launchpad",
       "icon": [
         "icons/32x32.png",
         "icons/128x128.png",

--- a/applications/launchpad_v2/src/App.test.tsx
+++ b/applications/launchpad_v2/src/App.test.tsx
@@ -1,9 +1,35 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
+import { randomFillSync } from 'crypto'
+import { mockIPC, clearMocks } from '@tauri-apps/api/mocks'
+
 import App from './App'
 
-test('renders learn react link', () => {
-  render(<App />)
+beforeAll(() => {
+  window.crypto = {
+    getRandomValues: function (buffer) {
+      return randomFillSync(buffer)
+    },
+  }
+})
+
+afterEach(() => {
+  clearMocks()
+})
+
+test('renders learn react link', async () => {
+  mockIPC((cmd) => {
+    switch (cmd) {
+    case 'invoke':
+      return ['a', 'b']
+    default:
+      break
+    }
+    return ['v']
+  })
+  await act(async () => {
+    render(<App />)
+  })
   const linkElement = screen.getByText(/learn react/i)
   expect(linkElement).toBeInTheDocument()
 })

--- a/applications/launchpad_v2/src/custom.d.ts
+++ b/applications/launchpad_v2/src/custom.d.ts
@@ -1,0 +1,5 @@
+declare module '*.svg' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const content: any
+  export default content
+}

--- a/applications/launchpad_v2/src/index.tsx
+++ b/applications/launchpad_v2/src/index.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
-import ReactDOM from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
 import reportWebVitals from './reportWebVitals'
 
-ReactDOM.render(
+const container = document.getElementById('root')
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+const root = createRoot(container!)
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root'),
+  </React.StrictMode>
 )
 
 // If you want to start measuring performance in your app, pass a function

--- a/applications/launchpad_v2/src/styles/Icons/types.tsx
+++ b/applications/launchpad_v2/src/styles/Icons/types.tsx
@@ -1,18 +1,19 @@
 /**
  * General JSDoc for IconComponents:
- * 
+ *
  * IconComponents created from exported Figma svg files using SVGR package
- * 
- * Components accept both inherited styling (color and fontSize) from parent and all native HTML SVG element attributes, e.g. width, height, color, etc. 
- * 
+ *
+ * Components accept both inherited styling (color and fontSize) from parent and all native HTML SVG element attributes, e.g. width, height, color, etc.
+ *
  * Components are imported for use with the prefix 'Svg', <Svg*filename* />
- * 
+ *
  * @example
  * <SvgAdd width={20} height={20} color={theme.icon.primary} />
- * 
+ *
  * --OR--
- * 
+ *
  * <SvgArrowRight />
  */
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SvgIconProps {}

--- a/applications/launchpad_v2/tsconfig.json
+++ b/applications/launchpad_v2/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
+    "types": ["node", "jest", "@testing-library/jest-dom"],
     "lib": [
       "dom",
       "dom.iterable",
@@ -21,6 +22,8 @@
     "jsx": "react-jsx"
   },
   "include": [
-    "src"
+    "src",
+    "./node_modules/**/*",
+    "./src/custom.d.ts"
   ]
 }


### PR DESCRIPTION
#56 

Description
---

**Changes**

- Add the job to the CircleCI that runs only for `launchpad*` branches (prefixed with `launchpad`), and enable CircleCi for our repo.
- Set up testing
- Upgrade React testing NPMs to remove warning and use new API to create a root: [Learn more](https://pl.reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis)
- Switch to `npm` in `package.json` scripts


Motivation and Context
---

Improve our development flow by checking eslint and tests with CI.

How Has This Been Tested?
---

Run on the CircleCI and using local machine.