### PR TITLE
fix: height of the large Tag

### DIFF
--- a/applications/launchpad_v2/src/components/Tag/styles.ts
+++ b/applications/launchpad_v2/src/components/Tag/styles.ts
@@ -6,7 +6,7 @@ export const TagContainer = styled.div<{ variant?: string }>`
   justify-content: center;
   align-items: center;
   border-radius: 64px;
-  height: ${({ variant }) => (variant === 'large' ? '30px' : '26px')};
+  height: 26px;
   border: 0;
   width: fit-content;
   padding-left: 12px;

--- a/applications/launchpad_v2/src/components/Text/index.tsx
+++ b/applications/launchpad_v2/src/components/Text/index.tsx
@@ -26,7 +26,6 @@ const Text = ({
 }: TextProps) => {
   const textStyles = {
     color,
-    ...style,
     ...styles.typography[type],
     ...style,
   }

--- a/applications/launchpad_v2/src/containers/BaseNodeContainer/BaseNode.tsx
+++ b/applications/launchpad_v2/src/containers/BaseNodeContainer/BaseNode.tsx
@@ -47,7 +47,11 @@ const BaseNode = ({
         color={running ? theme.inverted.primary : undefined}
       >
         {t.baseNode.title}
-        {running && <Tag type='running'>{t.common.adjectives.running}</Tag>}
+        {running && (
+          <Tag type='running' variant='large'>
+            {t.common.adjectives.running}
+          </Tag>
+        )}
       </Text>
       <Box
         border={false}


### PR DESCRIPTION
Description
---

Change the size of the large Tag component to `26px` and change the Tag variant in the `BaseNodeContainer`

Motivation and Context
---

#81 (Review)

How Has This Been Tested?
---

