### PR TITLE
feat: mining dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,32 @@
 version = 3
 
 [[package]]
+name = "TariLaunchpad"
+version = "0.1.0"
+dependencies = [
+ "bollard",
+ "config",
+ "derivative",
+ "env_logger 0.9.0",
+ "futures 0.3.21",
+ "log",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.23.0",
+ "strum_macros 0.23.1",
+ "tari_app_utilities",
+ "tari_common",
+ "tari_comms",
+ "tauri",
+ "tauri-build",
+ "thiserror",
+ "tokio 1.17.0",
+ "tor-hash-passwd",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,32 +178,6 @@ name = "anyhow"
 version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
-
-[[package]]
-name = "app"
-version = "0.1.0"
-dependencies = [
- "bollard",
- "config",
- "derivative",
- "env_logger 0.9.0",
- "futures 0.3.21",
- "log",
- "rand 0.8.5",
- "regex",
- "serde",
- "serde_json",
- "strum 0.23.0",
- "strum_macros 0.23.1",
- "tari_app_utilities",
- "tari_common",
- "tari_comms",
- "tauri",
- "tauri-build",
- "thiserror",
- "tokio 1.17.0",
- "tor-hash-passwd",
-]
 
 [[package]]
 name = "arc-swap"

--- a/applications/launchpad_v2/src/components/Box/index.tsx
+++ b/applications/launchpad_v2/src/components/Box/index.tsx
@@ -15,7 +15,13 @@ import { BoxProps } from './types'
  * @prop {string} end - color on gradient end
  * @prop {number} rotation - gradient rotation in degress (45 by default)
  */
-const Box = ({ children, gradient, border, style: inlineStyle }: BoxProps) => {
+const Box = ({
+  children,
+  gradient,
+  border,
+  style: inlineStyle,
+  testId = 'box-cmp',
+}: BoxProps) => {
   const style = {
     border: border === false ? 'none' : undefined,
     background:
@@ -29,7 +35,11 @@ const Box = ({ children, gradient, border, style: inlineStyle }: BoxProps) => {
     ...inlineStyle,
   }
 
-  return <StyledBox style={style}>{children}</StyledBox>
+  return (
+    <StyledBox style={style} data-testid={testId}>
+      {children}
+    </StyledBox>
+  )
 }
 
 export default Box

--- a/applications/launchpad_v2/src/components/Box/types.ts
+++ b/applications/launchpad_v2/src/components/Box/types.ts
@@ -11,4 +11,5 @@ export type BoxProps = {
   border?: boolean
   style?: CSSProperties
   gradient?: Gradient
+  testId?: string
 }

--- a/applications/launchpad_v2/src/components/Button/styles.ts
+++ b/applications/launchpad_v2/src/components/Button/styles.ts
@@ -40,7 +40,7 @@ export const StyledButton = styled.button<
     return `1px solid ${theme.accent}`
   }};
   box-shadow: none;
-  padding: ${({ theme }) => theme.spacingVertical()}
+  padding: ${({ theme }) => theme.spacingVertical(0.6)}
     ${({ theme }) => theme.spacingHorizontal()};
   cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
   background: ${getButtonBackgroundColor};

--- a/applications/launchpad_v2/src/components/CoinsList/index.tsx
+++ b/applications/launchpad_v2/src/components/CoinsList/index.tsx
@@ -1,0 +1,49 @@
+import Loading from '../Loading'
+import Text from '../Text'
+
+import { CoinsListItem, StyledCoinsList } from './styles'
+import { CoinsListProps } from './types'
+
+/**
+ * Render the list of coins with amount.
+ * @param {CoinProps[]} coins - the list of coins
+ * @param {string} [color = 'inherit'] - the text color
+ *
+ * @typedef {CoinProps}
+ * @param {string} amount - the amount
+ * @param {string} unit - the unit, ie. xtr
+ * @param {string} [suffixText] - the latter text after the amount and unit
+ * @param {boolean} [loading] - is value being loaded
+ */
+const CoinsList = ({ coins, color }: CoinsListProps) => {
+  return (
+    <StyledCoinsList color={color}>
+      {coins.map((c, idx) => (
+        <CoinsListItem key={`coin-${idx}`} loading={c.loading}>
+          {c.loading ? (
+            <Loading loading={true} style={{ marginRight: 12 }} />
+          ) : null}
+          <Text type='subheader'>{c.amount}</Text>
+          <Text
+            as='span'
+            type='smallMedium'
+            style={{
+              paddingLeft: 4,
+              paddingRight: 4,
+              textTransform: 'uppercase',
+            }}
+          >
+            {c.unit}
+          </Text>
+          {c.suffixText ? (
+            <Text as='span' type='smallMedium'>
+              {c.suffixText}
+            </Text>
+          ) : null}
+        </CoinsListItem>
+      ))}
+    </StyledCoinsList>
+  )
+}
+
+export default CoinsList

--- a/applications/launchpad_v2/src/components/CoinsList/styles.ts
+++ b/applications/launchpad_v2/src/components/CoinsList/styles.ts
@@ -1,0 +1,14 @@
+import styled from 'styled-components'
+
+export const StyledCoinsList = styled.ul<{ color?: string }>`
+  color: ${({ color }) => (color ? color : 'inherit')};
+  list-style: none;
+  padding-left: 0;
+  margin-top: 0;
+`
+
+export const CoinsListItem = styled.li<{ loading?: boolean }>`
+  opacity: ${({ loading }) => (loading ? 0.64 : 1)};
+  display: flex;
+  align-items: center;
+`

--- a/applications/launchpad_v2/src/components/CoinsList/types.ts
+++ b/applications/launchpad_v2/src/components/CoinsList/types.ts
@@ -1,0 +1,11 @@
+export interface CoinProps {
+  amount: string
+  unit: string
+  suffixText?: string
+  loading?: boolean
+}
+
+export interface CoinsListProps {
+  coins: CoinProps[]
+  color?: string
+}

--- a/applications/launchpad_v2/src/components/NodeBox/NodeBox.test.tsx
+++ b/applications/launchpad_v2/src/components/NodeBox/NodeBox.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from 'styled-components'
+
+import themes from '../../styles/themes'
+
+import NodeBox from '.'
+
+describe('NodeBox', () => {
+  it('should render without crashing', async () => {
+    render(
+      <ThemeProvider theme={themes.light}>
+        <NodeBox />
+      </ThemeProvider>,
+    )
+
+    const el = screen.getByTestId('node-box-cmp')
+    expect(el).toBeInTheDocument()
+  })
+})

--- a/applications/launchpad_v2/src/components/NodeBox/index.tsx
+++ b/applications/launchpad_v2/src/components/NodeBox/index.tsx
@@ -1,6 +1,8 @@
 import Box from '../Box'
+import Tag from '../Tag'
 import Text from '../Text'
 
+import { BoxHeader, BoxContent } from './styles'
 import { NodeBoxProps } from './types'
 
 /**
@@ -17,11 +19,22 @@ import { NodeBoxProps } from './types'
  * @example
  * TODO
  */
-const NodeBox = ({ title, status = 'inactive' }: NodeBoxProps) => {
+const NodeBox = ({ title, tag, children }: NodeBoxProps) => {
   return (
     <Box testId='node-box-cmp'>
-      {title ? <Text>{title}</Text> : null}
-      <p>The box {status}</p>
+      <BoxHeader>
+        {tag ? (
+          <Tag type={tag.type} variant='large'>
+            {tag.text}
+          </Tag>
+        ) : null}
+      </BoxHeader>
+      {title ? (
+        <Text as='h2' type='header'>
+          {title}
+        </Text>
+      ) : null}
+      <BoxContent>{children}</BoxContent>
     </Box>
   )
 }

--- a/applications/launchpad_v2/src/components/NodeBox/index.tsx
+++ b/applications/launchpad_v2/src/components/NodeBox/index.tsx
@@ -1,0 +1,29 @@
+import Box from '../Box'
+import Text from '../Text'
+
+import { NodeBoxProps } from './types'
+
+/**
+ * The advanced Box component handling:
+ * - custom title
+ * - header tag
+ * - background depending on the status prop
+ *
+ * Used as a UI representation of the Node (aka. Docker container).
+ *
+ * @param {string} [title] - the box heading
+ * @param {NodeBoxStatusType} [status = 'inactive'] - the status of the box/node
+ *
+ * @example
+ * TODO
+ */
+const NodeBox = ({ title, status = 'inactive' }: NodeBoxProps) => {
+  return (
+    <Box testId='node-box-cmp'>
+      {title ? <Text>{title}</Text> : null}
+      <p>The box {status}</p>
+    </Box>
+  )
+}
+
+export default NodeBox

--- a/applications/launchpad_v2/src/components/NodeBox/index.tsx
+++ b/applications/launchpad_v2/src/components/NodeBox/index.tsx
@@ -2,8 +2,8 @@ import Box from '../Box'
 import Tag from '../Tag'
 import Text from '../Text'
 
-import { BoxHeader, BoxContent } from './styles'
-import { NodeBoxProps } from './types'
+import { BoxHeader, BoxContent, NodeBoxPlacholder } from './styles'
+import { NodeBoxContentPlaceholderProps, NodeBoxProps } from './types'
 
 /**
  * The advanced Box component handling:
@@ -11,17 +11,25 @@ import { NodeBoxProps } from './types'
  * - header tag
  * - background depending on the status prop
  *
- * Used as a UI representation of the Node (aka. Docker container).
+ * Used for the UI representation of the Node (Docker container) as a Box component.
  *
  * @param {string} [title] - the box heading
- * @param {NodeBoxStatusType} [status = 'inactive'] - the status of the box/node
- *
- * @example
- * TODO
+ * @param {{ text: string; type?: TagType }} [tag = 'inactive'] - the status of the box/node
+ * @param {CSSWithSpring} [style] - the box style
+ * @param {CSSWithSpring} [titleStyle] - the title style
+ * @param {CSSWithSpring} [contentStyle] - the content style
+ * @param {ReactNode} [children] - the box heading
  */
-const NodeBox = ({ title, tag, children }: NodeBoxProps) => {
+const NodeBox = ({
+  title,
+  tag,
+  style,
+  titleStyle,
+  contentStyle,
+  children,
+}: NodeBoxProps) => {
   return (
-    <Box testId='node-box-cmp'>
+    <Box testId='node-box-cmp' style={style}>
       <BoxHeader>
         {tag ? (
           <Tag type={tag.type} variant='large'>
@@ -30,13 +38,29 @@ const NodeBox = ({ title, tag, children }: NodeBoxProps) => {
         ) : null}
       </BoxHeader>
       {title ? (
-        <Text as='h2' type='header'>
+        <Text as='h2' type='header' style={titleStyle}>
           {title}
         </Text>
       ) : null}
-      <BoxContent>{children}</BoxContent>
+      <BoxContent style={contentStyle}>{children}</BoxContent>
     </Box>
   )
+}
+
+/**
+ * Simple placholder container for the node box that provides default spacing and layout.
+ * @param {string | ReactNode} children - the content
+ */
+export const NodeBoxContentPlaceholder = ({
+  children,
+}: NodeBoxContentPlaceholderProps) => {
+  let content = children
+
+  if (typeof children === 'string') {
+    content = <Text color='inherit'>{children}</Text>
+  }
+
+  return <NodeBoxPlacholder>{content}</NodeBoxPlacholder>
 }
 
 export default NodeBox

--- a/applications/launchpad_v2/src/components/NodeBox/styles.ts
+++ b/applications/launchpad_v2/src/components/NodeBox/styles.ts
@@ -1,0 +1,3 @@
+import styled from 'styled-components'
+
+export const StyledBox = styled.div``

--- a/applications/launchpad_v2/src/components/NodeBox/styles.ts
+++ b/applications/launchpad_v2/src/components/NodeBox/styles.ts
@@ -1,3 +1,10 @@
 import styled from 'styled-components'
 
-export const StyledBox = styled.div``
+export const BoxHeader = styled.div`
+  height: 36px;
+`
+
+export const BoxContent = styled.div`
+  padding-top: ${({ theme }) => theme.spacingVertical(1)};
+  padding-bottom: ${({ theme }) => theme.spacingVertical(1)};
+`

--- a/applications/launchpad_v2/src/components/NodeBox/styles.ts
+++ b/applications/launchpad_v2/src/components/NodeBox/styles.ts
@@ -7,4 +7,14 @@ export const BoxHeader = styled.div`
 export const BoxContent = styled.div`
   padding-top: ${({ theme }) => theme.spacingVertical(1)};
   padding-bottom: ${({ theme }) => theme.spacingVertical(1)};
+  min-height: 136px;
+  display: flex;
+  flex-direction: column;
+`
+
+export const NodeBoxPlacholder = styled.div`
+  display: flex;
+  flex: 1;
+  padding-top: ${({ theme }) => theme.spacingVertical(1)};
+  padding-bottom: ${({ theme }) => theme.spacingVertical(1)};
 `

--- a/applications/launchpad_v2/src/components/NodeBox/types.ts
+++ b/applications/launchpad_v2/src/components/NodeBox/types.ts
@@ -1,0 +1,6 @@
+export type NodeBoxStatusType = 'inactive' | 'active'
+
+export interface NodeBoxProps {
+  title?: string
+  status?: NodeBoxStatusType
+}

--- a/applications/launchpad_v2/src/components/NodeBox/types.ts
+++ b/applications/launchpad_v2/src/components/NodeBox/types.ts
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react'
+import { CSSWithSpring } from '../../types/general'
 import { TagType } from '../Tag/types'
 
 export interface NodeBoxProps {
@@ -7,5 +8,12 @@ export interface NodeBoxProps {
     text: string
     type?: TagType
   }
+  style?: CSSWithSpring
+  titleStyle?: CSSWithSpring
+  contentStyle?: CSSWithSpring
   children?: ReactNode
+}
+
+export interface NodeBoxContentPlaceholderProps {
+  children: string | ReactNode
 }

--- a/applications/launchpad_v2/src/components/NodeBox/types.ts
+++ b/applications/launchpad_v2/src/components/NodeBox/types.ts
@@ -1,6 +1,11 @@
-export type NodeBoxStatusType = 'inactive' | 'active'
+import { ReactNode } from 'react'
+import { TagType } from '../Tag/types'
 
 export interface NodeBoxProps {
   title?: string
-  status?: NodeBoxStatusType
+  tag?: {
+    text: string
+    type?: TagType
+  }
+  children?: ReactNode
 }

--- a/applications/launchpad_v2/src/components/Switch/styles.ts
+++ b/applications/launchpad_v2/src/components/Switch/styles.ts
@@ -11,12 +11,15 @@ export const SwitchContainer = styled.label`
 export const SwitchController = styled(animated.div)`
   height: 14px;
   width: 24px;
-  border: 1.5px solid ${colors.dark.primary};
+  border: 1px solid ${colors.dark.primary};
   border-radius: 6px;
   position: relative;
   box-sizing: border-box;
   box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.08);
   cursor: pointer;
+  -webkit-box-shadow: 0px 0px 2px -1px ${colors.dark.primary};
+  -moz-box-shadow: 0px 0px 2px -1px ${colors.dark.primary};
+  box-shadow: 0px 0px 2px -1px ${colors.dark.primary};
 `
 
 export const SwitchCircle = styled(animated.div)`
@@ -28,7 +31,10 @@ export const SwitchCircle = styled(animated.div)`
   border-radius: 6px;
   box-sizing: border-box;
   background: #fff;
-  border: 1.5px solid ${colors.dark.primary};
+  border: 1px solid ${colors.dark.primary};
+  -webkit-box-shadow: 0px 0px 2px -1px ${colors.dark.primary};
+  -moz-box-shadow: 0px 0px 2px -1px ${colors.dark.primary};
+  box-shadow: 0px 0px 2px -1px ${colors.dark.primary};
 `
 
 export const LabelText = styled(animated.span)`

--- a/applications/launchpad_v2/src/components/Tag/index.tsx
+++ b/applications/launchpad_v2/src/components/Tag/index.tsx
@@ -12,7 +12,7 @@ import { TagContainer, IconWrapper } from './styles'
  *
  * @prop {ReactNode} [children] - text content to display
  * @prop {CSSProperties} [style] - optional component styles
- * @prop {'info' | 'running' | 'warning' | 'expert'} [type] - tag types to determine color settings
+ * @prop {'info' | 'running' | 'warning' | 'expert' | 'light'} [type] - tag types to determine color settings
  * @prop {ReactNode} [icon] - optional SVG icon
  * @prop {ReactNode} [subText] - optional additional tag text
  *
@@ -60,6 +60,14 @@ const Tag = ({
         backgroundImage: theme.expertText,
         WebkitBackgroundClip: 'text',
         color: 'transparent',
+      }
+      break
+    case 'light':
+      baseStyle = {
+        backgroundColor: theme.lightTag,
+      }
+      textStyle = {
+        color: theme.lightTagText,
       }
       break
     // info tag type is default

--- a/applications/launchpad_v2/src/components/Tag/types.ts
+++ b/applications/launchpad_v2/src/components/Tag/types.ts
@@ -2,7 +2,7 @@ import { ReactNode } from 'react'
 import { CSSProperties } from 'styled-components'
 
 export type TagVariantType = 'small' | 'large'
-export type TagType = 'info' | 'running' | 'warning' | 'expert'
+export type TagType = 'info' | 'running' | 'warning' | 'expert' | 'light'
 
 /**
  * @typedef TagProps

--- a/applications/launchpad_v2/src/containers/Dashboard/DashboardContainer/index.tsx
+++ b/applications/launchpad_v2/src/containers/Dashboard/DashboardContainer/index.tsx
@@ -1,4 +1,6 @@
 import { useSelector } from 'react-redux'
+import { CSSProperties } from 'styled-components'
+import { SpringValue } from 'react-spring'
 
 import { DashboardContent, DashboardLayout } from './styles'
 
@@ -14,7 +16,14 @@ import { selectView } from '../../../store/app/selectors'
 /**
  * Dashboard view containing three main tabs: Mining, Wallet and BaseNode
  */
-const DashboardContainer = () => {
+const DashboardContainer = ({
+  style,
+}: {
+  style?:
+    | CSSProperties
+    | Record<string, SpringValue<number>>
+    | Record<string, SpringValue<string>>
+}) => {
   const currentPage = useSelector(selectView)
 
   const renderPage = () => {
@@ -31,7 +40,7 @@ const DashboardContainer = () => {
   }
 
   return (
-    <DashboardLayout>
+    <DashboardLayout style={style}>
       <DashboardContent>
         <DashboardTabs />
         {renderPage()}

--- a/applications/launchpad_v2/src/containers/Dashboard/DashboardContainer/styles.ts
+++ b/applications/launchpad_v2/src/containers/Dashboard/DashboardContainer/styles.ts
@@ -1,6 +1,7 @@
+import { animated } from 'react-spring'
 import styled from 'styled-components'
 
-export const DashboardLayout = styled.div`
+export const DashboardLayout = styled(animated.div)`
   display: flex;
   flex-direction: column;
   height: 100%;

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningBox/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningBox/index.tsx
@@ -1,0 +1,151 @@
+import NodeBox from '../../../components/NodeBox'
+import Text from '../../../components/Text'
+import { TagType } from '../../../components/Tag/types'
+import { useAppDispatch, useAppSelector } from '../../../store/hooks'
+import { selectMiningNode } from '../../../store/mining/selectors'
+import { actions } from '../../../store/mining'
+import {
+  MiningNodesStatus,
+  MiningNodeStates,
+} from '../../../store/mining/types'
+
+import { MiningBoxProps } from './types'
+
+interface Config {
+  tag?: {
+    text: string
+    type?: TagType
+  }
+}
+
+const MiningBox = ({ node, children }: MiningBoxProps) => {
+  const dispatch = useAppDispatch()
+
+  const nodeState: MiningNodeStates = useAppSelector(state =>
+    selectMiningNode(state, node),
+  )
+
+  const defaultConfig = {
+    title: `${node.substring(0, 1).toUpperCase() + node.substring(1)} Mining`,
+  }
+
+  const defaultStates: Partial<{
+    [key in keyof typeof MiningNodesStatus]: Config
+  }> = {
+    UNKNOWN: {},
+    SETUP_REQUIRED: {
+      tag: {
+        text: 'Start here',
+      },
+    },
+    ERROR: {
+      tag: {
+        text: 'Problem',
+        type: 'warning',
+      },
+    },
+  }
+
+  const currentState = {
+    ...defaultConfig,
+    ...defaultStates[nodeState.status],
+  }
+
+  const componentForCurrentStatus = () => {
+    if (children) {
+      return children
+    }
+
+    switch (nodeState.status) {
+      case 'UNKNOWN':
+        return (
+          <div>
+            <Text>Unknown</Text>
+            <button
+              onClick={() =>
+                dispatch(
+                  actions.setNodeStatus({
+                    node: node,
+                    status: MiningNodesStatus.SETUP_REQUIRED,
+                  }),
+                )
+              }
+            >
+              Next
+            </button>
+          </div>
+        )
+      case 'SETUP_REQUIRED':
+        return (
+          <div>
+            <Text>Setup required</Text>
+            <button
+              onClick={() =>
+                dispatch(
+                  actions.setNodeStatus({
+                    node: node,
+                    status: MiningNodesStatus.ERROR,
+                  }),
+                )
+              }
+            >
+              Next
+            </button>
+          </div>
+        )
+      case 'ERROR':
+        return (
+          <div>
+            <Text>Error</Text>
+            <button
+              onClick={() =>
+                dispatch(
+                  actions.setNodeStatus({
+                    node: node,
+                    status: MiningNodesStatus.PAUSED,
+                  }),
+                )
+              }
+            >
+              Next
+            </button>
+          </div>
+        )
+      case 'PAUSED':
+        return (
+          <div>
+            <Text>Paused</Text>
+            <button
+              onClick={() => dispatch(actions.startMiningNode({ node: node }))}
+            >
+              Start
+            </button>
+          </div>
+        )
+      case 'RUNNING':
+        return (
+          <div>
+            <Text>Running</Text>
+            <button
+              onClick={() => dispatch(actions.stopMiningNode({ node: node }))}
+            >
+              Stop
+            </button>
+          </div>
+        )
+    }
+  }
+
+  console.log('MINING BOX a', node, nodeState.status)
+
+  const content = componentForCurrentStatus()
+
+  return (
+    <NodeBox title={currentState.title} tag={currentState.tag}>
+      {content}
+      {nodeState.pending ? <Text>Pending...</Text> : null}
+    </NodeBox>
+  )
+}
+
+export default MiningBox

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningBox/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningBox/index.tsx
@@ -42,7 +42,7 @@ const parseLastSessionToCoins = (lastSession: MiningSession | undefined) => {
         lastSession.total && lastSession.total[coin]
           ? lastSession.total[coin]
           : '0',
-      loading: false,
+      loading: true,
       suffixText: t.mining.minedInLastSession,
     }))
   }
@@ -113,12 +113,12 @@ const MiningBox = ({ node, children }: MiningBoxProps) => {
     UNKNOWN: {},
     SETUP_REQUIRED: {
       tag: {
-        text: t.common.pharses.startHere,
+        text: t.common.phrases.startHere,
       },
     },
     BLOCKED: {
       tag: {
-        text: t.common.pharses.actionRequired,
+        text: t.common.phrases.actionRequired,
         type: 'warning',
       },
     },

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningBox/styles.ts
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningBox/styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+export const MiningBoxContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+  flex: 1;
+`

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningBox/types.ts
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningBox/types.ts
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react'
 import { TagType } from '../../../components/Tag/types'
-import { MiningNodesStatus, NodeType } from '../../../store/mining/types'
+import { MiningNodesStatus } from '../../../store/mining/types'
+import { MiningNodeType } from '../../../types/general'
 
 export interface NodeBoxStatusConfig {
   tag: {
@@ -10,7 +11,7 @@ export interface NodeBoxStatusConfig {
 }
 
 export interface MiningBoxProps {
-  node: NodeType
+  node: MiningNodeType
   statuses?: Record<keyof MiningNodesStatus, NodeBoxStatusConfig>
   children?: ReactNode
 }

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningBox/types.ts
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningBox/types.ts
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react'
+import { TagType } from '../../../components/Tag/types'
+import { MiningNodesStatus, NodeType } from '../../../store/mining/types'
+
+export interface NodeBoxStatusConfig {
+  tag: {
+    text: string
+    type: TagType
+  }
+}
+
+export interface MiningBoxProps {
+  node: NodeType
+  statuses?: Record<keyof MiningNodesStatus, NodeBoxStatusConfig>
+  children?: ReactNode
+}

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxMerged/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxMerged/index.tsx
@@ -1,17 +1,6 @@
-import Button from '../../../components/Button'
-import NodeBox from '../../../components/NodeBox'
-
-import { useAppDispatch, useAppSelector } from '../../../store/hooks'
-
-import { actions as miningActions } from '../../../store/mining'
-import { selectMiningNode } from '../../../store/mining/selectors'
 import MiningBox from '../MiningBox'
 
 const MiningBoxMerged = () => {
-  // const dispatch = useAppDispatch()
-  // const miningState = useAppSelector(state => selectMiningNode(state, 'merged'))
-  console.log('MERGED ----')
-
   return <MiningBox node='merged' />
 }
 

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxMerged/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxMerged/index.tsx
@@ -1,7 +1,18 @@
+import Button from '../../../components/Button'
 import NodeBox from '../../../components/NodeBox'
 
+import { useAppDispatch, useAppSelector } from '../../../store/hooks'
+
+import { actions as miningActions } from '../../../store/mining'
+import { selectMiningNode } from '../../../store/mining/selectors'
+import MiningBox from '../MiningBox'
+
 const MiningBoxMerged = () => {
-  return <NodeBox title='Merged' />
+  // const dispatch = useAppDispatch()
+  // const miningState = useAppSelector(state => selectMiningNode(state, 'merged'))
+  console.log('MERGED ----')
+
+  return <MiningBox node='merged' />
 }
 
 export default MiningBoxMerged

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxMerged/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxMerged/index.tsx
@@ -1,0 +1,7 @@
+import NodeBox from '../../../components/NodeBox'
+
+const MiningBoxMerged = () => {
+  return <NodeBox title='Merged' />
+}
+
+export default MiningBoxMerged

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxTari/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxTari/index.tsx
@@ -1,0 +1,7 @@
+import NodeBox from '../../../components/NodeBox'
+
+const MiningBoxTari = () => {
+  return <NodeBox title='Tari' />
+}
+
+export default MiningBoxTari

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxTari/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxTari/index.tsx
@@ -1,7 +1,69 @@
+import Button from '../../../components/Button'
 import NodeBox from '../../../components/NodeBox'
 
+import { useAppDispatch, useAppSelector } from '../../../store/hooks'
+
+import { actions as miningActions } from '../../../store/mining'
+import { selectMiningNode } from '../../../store/mining/selectors'
+import { MiningNodeState } from '../../../store/mining/types'
+import { selectState as selectWalletState } from '../../../store/wallet/selectors'
+import MiningBox from '../MiningBox'
+
 const MiningBoxTari = () => {
-  return <NodeBox title='Tari' />
+  // const dispatch = useAppDispatch()
+  const miningState = useAppSelector(state => selectMiningNode(state, 'tari'))
+  const walletState = useAppSelector(selectWalletState)
+  console.log('TARI ----')
+
+  /* 3-4 states here
+    1. Disabled - missing wallet (or wallet has not been configured) - this is pretty much custom, sometimes it depends on many reasons
+    2. Inactive 1 - nothing mined 
+    3. Inactive 2 - paused - running false, but something has been already mined
+    4. Active - running
+  */
+
+  const defaultProps = {
+    title: 'Tari mining',
+    chains: ['XTR'],
+    style: {
+      box: {
+        background: '#fff',
+        color: '#222',
+      },
+    },
+  }
+
+  const statusesConfig = {
+    configure: {
+      tag: {
+        text: 'Start here',
+        type: 'default',
+      },
+    },
+    paused: {},
+    running: {
+      style: {
+        box: {
+          background: 'red',
+          color: '#fff',
+        },
+      },
+    },
+  }
+
+  const evaluateStatus = () => {
+    if (walletState.address && walletState.address.length > 1) {
+      return 'configure'
+    }
+
+    if (miningState.running) {
+      return 'running'
+    }
+
+    return 'paused'
+  }
+
+  return <MiningBox node='tari' />
 }
 
 export default MiningBoxTari

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxTari/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningBoxTari/index.tsx
@@ -1,68 +1,6 @@
-import Button from '../../../components/Button'
-import NodeBox from '../../../components/NodeBox'
-
-import { useAppDispatch, useAppSelector } from '../../../store/hooks'
-
-import { actions as miningActions } from '../../../store/mining'
-import { selectMiningNode } from '../../../store/mining/selectors'
-import { MiningNodeState } from '../../../store/mining/types'
-import { selectState as selectWalletState } from '../../../store/wallet/selectors'
 import MiningBox from '../MiningBox'
 
 const MiningBoxTari = () => {
-  // const dispatch = useAppDispatch()
-  const miningState = useAppSelector(state => selectMiningNode(state, 'tari'))
-  const walletState = useAppSelector(selectWalletState)
-  console.log('TARI ----')
-
-  /* 3-4 states here
-    1. Disabled - missing wallet (or wallet has not been configured) - this is pretty much custom, sometimes it depends on many reasons
-    2. Inactive 1 - nothing mined 
-    3. Inactive 2 - paused - running false, but something has been already mined
-    4. Active - running
-  */
-
-  const defaultProps = {
-    title: 'Tari mining',
-    chains: ['XTR'],
-    style: {
-      box: {
-        background: '#fff',
-        color: '#222',
-      },
-    },
-  }
-
-  const statusesConfig = {
-    configure: {
-      tag: {
-        text: 'Start here',
-        type: 'default',
-      },
-    },
-    paused: {},
-    running: {
-      style: {
-        box: {
-          background: 'red',
-          color: '#fff',
-        },
-      },
-    },
-  }
-
-  const evaluateStatus = () => {
-    if (walletState.address && walletState.address.length > 1) {
-      return 'configure'
-    }
-
-    if (miningState.running) {
-      return 'running'
-    }
-
-    return 'paused'
-  }
-
   return <MiningBox node='tari' />
 }
 

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningHeaderTip/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningHeaderTip/index.tsx
@@ -1,0 +1,25 @@
+import t from '../../../locales'
+
+import Button from '../../../components/Button'
+import Text from '../../../components/Text'
+
+import SvgStar from '../../../styles/Icons/Star'
+import SvgInfo1 from '../../../styles/Icons/Info1'
+import { StyledMiningHeaderTip } from './styles'
+
+/**
+ * @TODO - draft - add other states
+ */
+const MiningHeaderTip = () => {
+  return (
+    <StyledMiningHeaderTip>
+      <SvgStar />
+      <Text>{t.mining.headerTips.oneStepAway}</Text>
+      <Button type='link' href='https://google.com' rightIcon={<SvgInfo1 />}>
+        {t.mining.headerTips.wantToKnowMore}
+      </Button>
+    </StyledMiningHeaderTip>
+  )
+}
+
+export default MiningHeaderTip

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningHeaderTip/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningHeaderTip/index.tsx
@@ -13,9 +13,14 @@ import { StyledMiningHeaderTip } from './styles'
 const MiningHeaderTip = () => {
   return (
     <StyledMiningHeaderTip>
-      <SvgStar />
+      <SvgStar height={18} width={18} style={{ marginRight: 8 }} />
       <Text>{t.mining.headerTips.oneStepAway}</Text>
-      <Button type='link' href='https://google.com' rightIcon={<SvgInfo1 />}>
+      <Button
+        type='link'
+        variant='text'
+        href='https://google.com'
+        rightIcon={<SvgInfo1 />}
+      >
         {t.mining.headerTips.wantToKnowMore}
       </Button>
     </StyledMiningHeaderTip>

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningHeaderTip/styles.ts
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningHeaderTip/styles.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+
+export const StyledMiningHeaderTip = styled.div`
+  display: flex;
+  margin-top: ${({ theme }) => theme.spacingVertical(3)};
+  margin-bottom: ${({ theme }) => theme.spacingVertical(2.392)};
+`

--- a/applications/launchpad_v2/src/containers/MiningContainer/MiningViewActions/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/MiningViewActions/index.tsx
@@ -1,0 +1,26 @@
+import Button from '../../../components/Button'
+import t from '../../../locales'
+import SvgChart from '../../../styles/Icons/Chart'
+import SvgClock from '../../../styles/Icons/Clock'
+import SvgSetting2 from '../../../styles/Icons/Setting2'
+
+/**
+ * Renders set of links/actions in Mining dashboard
+ */
+const MiningViewActions = () => {
+  return (
+    <div>
+      <Button variant='text' leftIcon={<SvgClock />}>
+        {t.mining.viewActions.setUpMiningHours}
+      </Button>
+      <Button variant='text' leftIcon={<SvgSetting2 />}>
+        {t.mining.viewActions.miningSettings}
+      </Button>
+      <Button variant='text' leftIcon={<SvgChart />}>
+        {t.mining.viewActions.statistics}
+      </Button>
+    </div>
+  )
+}
+
+export default MiningViewActions

--- a/applications/launchpad_v2/src/containers/MiningContainer/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/index.tsx
@@ -5,32 +5,50 @@ import Text from '../../components/Text'
 import SvgSun from '../../styles/Icons/Sun'
 import SvgMoon from '../../styles/Icons/Moon'
 
+import MiningHeaderTip from './MiningHeaderTip'
+import MiningViewActions from './MiningViewActions'
+
 import { setTheme } from '../../store/app'
 import { selectTheme } from '../../store/app/selectors'
 
-/**
- * @TODO move user-facing text to i18n file when implementing
- */
+import { NodesContainer } from './styles'
+import MiningBoxTari from './MiningBoxTari'
+import MiningBoxMerged from './MiningBoxMerged'
 
+/**
+ * The Mining dashboard
+ */
 const MiningContainer = () => {
   const dispatch = useDispatch()
   const currentTheme = useSelector(selectTheme)
 
   return (
     <div>
-      <h2>Mining</h2>
-      <button onClick={() => dispatch(setTheme('light'))}>
-        Set light theme
-      </button>
-      <button onClick={() => dispatch(setTheme('dark'))}>Set dark theme</button>
-      <div>
-        <Text>Select theme</Text>
-        <Switch
-          leftLabel={<SvgSun width='1.4em' height='1.4em' />}
-          rightLabel={<SvgMoon width='1.4em' height='1.4em' />}
-          value={currentTheme === 'dark'}
-          onClick={v => dispatch(setTheme(v ? 'dark' : 'light'))}
-        />
+      <MiningHeaderTip />
+
+      <NodesContainer>
+        <MiningBoxTari />
+        <MiningBoxMerged />
+      </NodesContainer>
+
+      <MiningViewActions />
+
+      <div style={{ marginTop: 80 }}>
+        <button onClick={() => dispatch(setTheme('light'))}>
+          Set light theme
+        </button>
+        <button onClick={() => dispatch(setTheme('dark'))}>
+          Set dark theme
+        </button>
+        <div>
+          <Text>Select theme</Text>
+          <Switch
+            leftLabel={<SvgSun width='1.4em' height='1.4em' />}
+            rightLabel={<SvgMoon width='1.4em' height='1.4em' />}
+            value={currentTheme === 'dark'}
+            onClick={v => dispatch(setTheme(v ? 'dark' : 'light'))}
+          />
+        </div>
       </div>
     </div>
   )

--- a/applications/launchpad_v2/src/containers/MiningContainer/index.tsx
+++ b/applications/launchpad_v2/src/containers/MiningContainer/index.tsx
@@ -1,4 +1,4 @@
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import Switch from '../../components/Switch'
 
 import Text from '../../components/Text'
@@ -14,12 +14,14 @@ import { selectTheme } from '../../store/app/selectors'
 import { NodesContainer } from './styles'
 import MiningBoxTari from './MiningBoxTari'
 import MiningBoxMerged from './MiningBoxMerged'
+import { actions } from '../../store/wallet'
+import { useAppDispatch } from '../../store/hooks'
 
 /**
  * The Mining dashboard
  */
 const MiningContainer = () => {
-  const dispatch = useDispatch()
+  const dispatch = useAppDispatch()
   const currentTheme = useSelector(selectTheme)
 
   return (
@@ -32,6 +34,14 @@ const MiningContainer = () => {
       </NodesContainer>
 
       <MiningViewActions />
+
+      <button onClick={() => dispatch(actions.unlockWallet('pass'))}>
+        Set pass
+      </button>
+
+      <button onClick={() => dispatch(actions.unlockWallet(''))}>
+        Clear pass
+      </button>
 
       <div style={{ marginTop: 80 }}>
         <button onClick={() => dispatch(setTheme('light'))}>

--- a/applications/launchpad_v2/src/containers/MiningContainer/styles.ts
+++ b/applications/launchpad_v2/src/containers/MiningContainer/styles.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components'
+
+export const NodesContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+
+  & > div {
+    margin: ${({ theme }) => theme.spacing(0.34)};
+  }
+  & > div:first-child {
+    margin-left: 0;
+  }
+  & > div:last-child {
+    margin-right: 0;
+  }
+`

--- a/applications/launchpad_v2/src/custom.d.ts
+++ b/applications/launchpad_v2/src/custom.d.ts
@@ -43,6 +43,8 @@ declare module 'styled-components' {
     warningText: string
     expert: string
     expertText: string
+    lightTag: string
+    lightTagText: string
     placeholderText: string
 
     inverted: {
@@ -65,6 +67,8 @@ declare module 'styled-components' {
       warningText: string
       expert: string
       expertText: string
+      lightTag: string
+      lightTagText: string
     }
   }
 }

--- a/applications/launchpad_v2/src/layouts/MainLayout/index.tsx
+++ b/applications/launchpad_v2/src/layouts/MainLayout/index.tsx
@@ -59,6 +59,8 @@ const MainLayout = ({ drawerViewWidth = '50%' }: MainLayoutProps) => {
    */
   const mainContainerStyle = useSpring({
     width: expertView === 'open' ? invertedExpertViewSize : '100%',
+  })
+  const dashboardContainerStyle = useSpring({
     paddingLeft: expertView === 'open' || tightSpace ? 40 : 100,
     paddingRight: expertView === 'open' || tightSpace ? 40 : 100,
   })
@@ -83,7 +85,7 @@ const MainLayout = ({ drawerViewWidth = '50%' }: MainLayoutProps) => {
             ...mainContainerStyle,
           }}
         >
-          <DashboardContainer />
+          <DashboardContainer style={{ ...dashboardContainerStyle }} />
         </MainContainer>
 
         {/* Background overlay: */}

--- a/applications/launchpad_v2/src/locales/common.ts
+++ b/applications/launchpad_v2/src/locales/common.ts
@@ -17,7 +17,7 @@ const translations = {
     running: 'Running',
     paused: 'Paused',
   },
-  pharses: {
+  phrases: {
     actionRequired: 'Action required',
     startHere: 'Start here',
   },

--- a/applications/launchpad_v2/src/locales/common.ts
+++ b/applications/launchpad_v2/src/locales/common.ts
@@ -3,16 +3,23 @@ const translations = {
     accept: 'Accept',
     cancel: 'Cancel',
     stop: 'Stop',
+    pause: 'Pause',
     continue: 'Continue',
   },
   nouns: {
     baseNode: 'Base Node',
     mining: 'Mining',
+    problem: 'Problem',
     settings: 'Settings',
     wallet: 'Wallet',
   },
   adjectives: {
     running: 'Running',
+    paused: 'Paused',
+  },
+  pharses: {
+    actionRequired: 'Action required',
+    startHere: 'Start here',
   },
 }
 

--- a/applications/launchpad_v2/src/locales/mining.ts
+++ b/applications/launchpad_v2/src/locales/mining.ts
@@ -1,5 +1,14 @@
 const translations = {
   set_up_mining_hours: 'Set up mining hours',
+  headerTips: {
+    oneStepAway: 'You are one step away from staring mining.',
+    wantToKnowMore: 'Want to know more',
+  },
+  viewActions: {
+    setUpMiningHours: 'Set up mining hours',
+    miningSettings: 'Mining settings',
+    statistics: 'Statistics',
+  },
 }
 
 export default translations

--- a/applications/launchpad_v2/src/locales/mining.ts
+++ b/applications/launchpad_v2/src/locales/mining.ts
@@ -1,13 +1,23 @@
 const translations = {
   set_up_mining_hours: 'Set up mining hours',
+  minedInLastSession: 'mined in last session',
   headerTips: {
     oneStepAway: 'You are one step away from staring mining.',
     wantToKnowMore: 'Want to know more',
+  },
+  actions: {
+    startMining: 'Start mining',
   },
   viewActions: {
     setUpMiningHours: 'Set up mining hours',
     miningSettings: 'Mining settings',
     statistics: 'Statistics',
+  },
+  placeholders: {
+    statusUnknown: 'The node status is unknown.',
+    statusBlocked: 'The node cannot be started.',
+    statusSetupRequired: 'The node requires further configuration.',
+    statusError: 'The node failed.',
   },
 }
 

--- a/applications/launchpad_v2/src/store/index.ts
+++ b/applications/launchpad_v2/src/store/index.ts
@@ -1,13 +1,15 @@
 import { configureStore } from '@reduxjs/toolkit'
 
-import baseNodeReducer from './baseNode'
-import walletReducer from './wallet'
 import appReducer from './app'
+import baseNodeReducer from './baseNode'
+import miningReducer from './mining'
+import walletReducer from './wallet'
 
 // exported for tests
 export const rootReducer = {
   app: appReducer,
   baseNode: baseNodeReducer,
+  mining: miningReducer,
   wallet: walletReducer,
 }
 

--- a/applications/launchpad_v2/src/store/mining/index.ts
+++ b/applications/launchpad_v2/src/store/mining/index.ts
@@ -1,0 +1,66 @@
+import { createSlice } from '@reduxjs/toolkit'
+import { startMiningNode, stopMiningNode } from './thunks'
+
+import { MiningNodesStatus, MiningState, NodeType } from './types'
+
+export const initialState: MiningState = {
+  tari: {
+    pending: false,
+    status: MiningNodesStatus.UNKNOWN,
+  },
+  merged: {
+    pending: false,
+    status: MiningNodesStatus.RUNNING,
+  },
+}
+
+const miningSlice = createSlice({
+  name: 'mining',
+  initialState,
+  reducers: {
+    setNodeStatus(
+      state,
+      { payload }: { payload: { node: NodeType; status: MiningNodesStatus } },
+    ) {
+      state[payload.node].status = payload.status
+    },
+  },
+  extraReducers: builder => {
+    builder
+      .addCase(startMiningNode.pending, (state, action) => {
+        const node = action.meta.arg.node
+        if (node in state) {
+          state[node].pending = true
+        }
+      })
+      .addCase(startMiningNode.fulfilled, (state, action) => {
+        const node = action.meta.arg.node
+        if (node in state) {
+          state[node].pending = false
+          state[node].status = MiningNodesStatus.RUNNING
+        }
+      })
+      .addCase(stopMiningNode.pending, (state, action) => {
+        const node = action.meta.arg.node
+        if (node in state) {
+          state[node].pending = true
+        }
+      })
+      .addCase(stopMiningNode.fulfilled, (state, action) => {
+        const node = action.meta.arg.node
+        if (node in state) {
+          state[node].pending = false
+          state[node].status = MiningNodesStatus.PAUSED
+        }
+      })
+  },
+})
+
+const { setNodeStatus } = miningSlice.actions
+export const actions = {
+  setNodeStatus,
+  startMiningNode,
+  stopMiningNode,
+}
+
+export default miningSlice.reducer

--- a/applications/launchpad_v2/src/store/mining/index.ts
+++ b/applications/launchpad_v2/src/store/mining/index.ts
@@ -1,16 +1,43 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { MiningNodeType } from '../../types/general'
 import { startMiningNode, stopMiningNode } from './thunks'
 
-import { MiningNodesStatus, MiningState, NodeType } from './types'
+import { MiningNodesStatus, MiningState } from './types'
 
 export const initialState: MiningState = {
   tari: {
     pending: false,
-    status: MiningNodesStatus.UNKNOWN,
+    status: MiningNodesStatus.PAUSED,
+    sessions: [
+      {
+        total: {
+          xtr: '1000',
+        },
+      },
+      {
+        total: {
+          xtr: '2000',
+        },
+      },
+    ],
   },
   merged: {
     pending: false,
-    status: MiningNodesStatus.RUNNING,
+    status: MiningNodesStatus.PAUSED,
+    sessions: [
+      {
+        total: {
+          xtr: '1000',
+          xmr: '1001',
+        },
+      },
+      {
+        total: {
+          xtr: '2000',
+          xmr: '2001',
+        },
+      },
+    ],
   },
 }
 
@@ -20,7 +47,9 @@ const miningSlice = createSlice({
   reducers: {
     setNodeStatus(
       state,
-      { payload }: { payload: { node: NodeType; status: MiningNodesStatus } },
+      {
+        payload,
+      }: { payload: { node: MiningNodeType; status: MiningNodesStatus } },
     ) {
       state[payload.node].status = payload.status
     },

--- a/applications/launchpad_v2/src/store/mining/selectors.ts
+++ b/applications/launchpad_v2/src/store/mining/selectors.ts
@@ -1,0 +1,12 @@
+import { createSelector } from '@reduxjs/toolkit'
+import { NodeType } from './types'
+
+/**
+ * Get Redux state of the given mining node
+ * @example
+ * const miningState = useAppSelector(state => selectMiningNode(state, 'merged'))
+ */
+export const selectMiningNode = createSelector(
+  [state => state.mining, (_, node: NodeType) => node],
+  (miningState, node) => miningState[node],
+)

--- a/applications/launchpad_v2/src/store/mining/selectors.ts
+++ b/applications/launchpad_v2/src/store/mining/selectors.ts
@@ -1,5 +1,5 @@
 import { createSelector } from '@reduxjs/toolkit'
-import { NodeType } from './types'
+import { MiningNodeType } from '../../types/general'
 
 /**
  * Get Redux state of the given mining node
@@ -7,6 +7,17 @@ import { NodeType } from './types'
  * const miningState = useAppSelector(state => selectMiningNode(state, 'merged'))
  */
 export const selectMiningNode = createSelector(
-  [state => state.mining, (_, node: NodeType) => node],
+  [state => state.mining, (_, node: MiningNodeType) => node],
   (miningState, node) => miningState[node],
+)
+
+/**
+ * Get stats for last/current session
+ */
+export const selectLastSession = createSelector(
+  [state => state.mining, (_, node: MiningNodeType) => node],
+  (miningState, node) =>
+    miningState[node].sessions && miningState[node].sessions.length > 0
+      ? miningState[node].sessions[miningState[node].sessions.length - 1]
+      : undefined,
 )

--- a/applications/launchpad_v2/src/store/mining/thunks.ts
+++ b/applications/launchpad_v2/src/store/mining/thunks.ts
@@ -1,12 +1,12 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
-import { NodeType } from './types'
+import { MiningNodeType } from '../../types/general'
 
 /**
  * Start given mining node
  * @prop {NodeType} node - the node name, ie. 'tari', 'merged'
  * @returns {Promise<void>}
  */
-export const startMiningNode = createAsyncThunk<void, { node: NodeType }>(
+export const startMiningNode = createAsyncThunk<void, { node: MiningNodeType }>(
   'mining/startNode',
   async ({ node }) => {
     console.log(`starting ${node} node`)
@@ -19,7 +19,7 @@ export const startMiningNode = createAsyncThunk<void, { node: NodeType }>(
  * @prop {NodeType} node - the node name, ie. 'tari', 'merged'
  * @returns {Promise<void>}
  */
-export const stopMiningNode = createAsyncThunk<void, { node: NodeType }>(
+export const stopMiningNode = createAsyncThunk<void, { node: MiningNodeType }>(
   'mining/stopNode',
   async ({ node }) => {
     console.log(`stopping ${node} node`)

--- a/applications/launchpad_v2/src/store/mining/thunks.ts
+++ b/applications/launchpad_v2/src/store/mining/thunks.ts
@@ -1,0 +1,28 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { NodeType } from './types'
+
+/**
+ * Start given mining node
+ * @prop {NodeType} node - the node name, ie. 'tari', 'merged'
+ * @returns {Promise<void>}
+ */
+export const startMiningNode = createAsyncThunk<void, { node: NodeType }>(
+  'mining/startNode',
+  async ({ node }) => {
+    console.log(`starting ${node} node`)
+    return await new Promise(resolve => setTimeout(resolve, 2000))
+  },
+)
+
+/**
+ * Stop given mining node
+ * @prop {NodeType} node - the node name, ie. 'tari', 'merged'
+ * @returns {Promise<void>}
+ */
+export const stopMiningNode = createAsyncThunk<void, { node: NodeType }>(
+  'mining/stopNode',
+  async ({ node }) => {
+    console.log(`stopping ${node} node`)
+    return await new Promise(resolve => setTimeout(resolve, 2000))
+  },
+)

--- a/applications/launchpad_v2/src/store/mining/types.ts
+++ b/applications/launchpad_v2/src/store/mining/types.ts
@@ -1,30 +1,53 @@
-export type NodeType = 'tari' | 'merged'
-
+/**
+ * @TODO - the list of possible statuses may change.
+ * If so, then MiningBox and Mining Container may need to be changed as well.
+ * UNKNOWN - the status of the container/node is unknown, ie. on app launch it can be default status
+ * SETUP_REQUIRED - node/container cannot be run because of missing configuration (merge with BLOCKED?)
+ * BLOCKED - node/container cannot be run because some requirement is not satisfied, ie. mining node needs base node running
+ * PAUSED - node/container is not running. NOTE: node and container are not necessary the same. Ie. Docker container can be live, but process running inside the container can be stopped. So maybe we should split this also into PAUSED and STOPPED?
+ * RUNNING - node/container is running and healthy
+ * ERROR - node/container is failed
+ */
 export enum MiningNodesStatus {
   'UNKNOWN' = 'UNKNOWN',
   'SETUP_REQUIRED' = 'SETUP_REQUIRED',
+  'BLOCKED' = 'BLOCKED',
   'PAUSED' = 'PAUSED',
   'RUNNING' = 'RUNNING',
   'ERROR' = 'ERROR',
 }
 
-export enum DisabledReasonTari {
+export enum CodesOfTariMining {
   'MISSING_WALLET_ADDRESS',
 }
 
-export enum DisabledReasonMerged {
+export enum CodesOfMergedMining {
   'MISSING_WALLET_ADDRESS',
   'MISSING_MONERO_ADDRESS',
+}
+
+export interface MiningSession {
+  startedAt?: string // UTC timestamp
+  finishedAt?: string
+  id?: string // uuid (?)
+  total?: Record<string, string> // i,e { xtr: 1000 bignumber (?) }
+  history?: {
+    timestamp?: string // UTC timestamp
+    amount?: string // bignumber (?)
+    chain?: string // ie. xtr, xmr aka coin/currency?
+    type?: string // to enum, ie. mined, earned, received, sent
+  }[]
 }
 
 export interface MiningNodeState<TDisabledReason> {
   pending: boolean
   status: MiningNodesStatus
   disabledReason?: TDisabledReason
+  sessions?: MiningSession[]
 }
 
-export type TariMiningNodeState = MiningNodeState<DisabledReasonTari>
-export type MergedMiningNodeState = MiningNodeState<DisabledReasonMerged>
+export type TariMiningNodeState = MiningNodeState<CodesOfTariMining>
+export type MergedMiningNodeState = MiningNodeState<CodesOfMergedMining>
 
 export type MiningNodeStates = TariMiningNodeState | MergedMiningNodeState
 

--- a/applications/launchpad_v2/src/store/mining/types.ts
+++ b/applications/launchpad_v2/src/store/mining/types.ts
@@ -1,0 +1,34 @@
+export type NodeType = 'tari' | 'merged'
+
+export enum MiningNodesStatus {
+  'UNKNOWN' = 'UNKNOWN',
+  'SETUP_REQUIRED' = 'SETUP_REQUIRED',
+  'PAUSED' = 'PAUSED',
+  'RUNNING' = 'RUNNING',
+  'ERROR' = 'ERROR',
+}
+
+export enum DisabledReasonTari {
+  'MISSING_WALLET_ADDRESS',
+}
+
+export enum DisabledReasonMerged {
+  'MISSING_WALLET_ADDRESS',
+  'MISSING_MONERO_ADDRESS',
+}
+
+export interface MiningNodeState<TDisabledReason> {
+  pending: boolean
+  status: MiningNodesStatus
+  disabledReason?: TDisabledReason
+}
+
+export type TariMiningNodeState = MiningNodeState<DisabledReasonTari>
+export type MergedMiningNodeState = MiningNodeState<DisabledReasonMerged>
+
+export type MiningNodeStates = TariMiningNodeState | MergedMiningNodeState
+
+export interface MiningState {
+  tari: TariMiningNodeState
+  merged: MergedMiningNodeState
+}

--- a/applications/launchpad_v2/src/styles/themes/dark.ts
+++ b/applications/launchpad_v2/src/styles/themes/dark.ts
@@ -23,6 +23,8 @@ const darkTheme = {
   warningText: styles.colors.secondary.warningText,
   expert: 'rgba(147, 48, 255, 0.05)',
   expertText: styles.gradients.tari,
+  lightTag: styles.colors.light.backgroundImage,
+  lightTagText: styles.colors.dark.secondary,
   placeholderText: styles.colors.dark.placeholder,
 
   inverted: {
@@ -45,6 +47,8 @@ const darkTheme = {
     warningText: styles.colors.secondary.warningText,
     expert: 'rgba(147, 48, 255, 0.05)',
     expertText: styles.gradients.tari,
+    lightTag: styles.colors.light.backgroundImage,
+    lightTagText: styles.colors.dark.secondary,
     borderColor: styles.colors.light.backgroundImage,
     borderColorLight: styles.colors.secondary.borderLight,
     controlBackground: 'transparent',

--- a/applications/launchpad_v2/src/styles/themes/light.ts
+++ b/applications/launchpad_v2/src/styles/themes/light.ts
@@ -29,11 +29,13 @@ const lightTheme = {
   warningText: styles.colors.secondary.warningText,
   expert: 'rgba(147, 48, 255, 0.05)',
   expertText: styles.gradients.tari,
+  lightTag: styles.colors.light.backgroundImage,
+  lightTagText: styles.colors.dark.secondary,
   placeholderText: styles.colors.dark.placeholder,
 
   inverted: {
     primary: styles.colors.light.primary,
-    secondary: styles.colors.dark.secondary,
+    secondary: styles.colors.light.textSecondary,
     tertiary: styles.colors.dark.tertiary,
     background: styles.colors.darkMode.modalBackgroundSecondary,
     backgroundSecondary: styles.colors.darkMode.modalBackground,
@@ -51,6 +53,8 @@ const lightTheme = {
     warningText: styles.colors.secondary.warningText,
     expert: 'rgba(147, 48, 255, 0.05)',
     expertText: styles.gradients.tari,
+    lightTag: styles.colors.light.backgroundImage,
+    lightTagText: styles.colors.dark.secondary,
     borderColor: styles.colors.secondary.borderLight,
     borderColorLight: styles.colors.secondary.borderLight,
     actionBackground: styles.colors.secondary.actionBackground,

--- a/applications/launchpad_v2/src/types/general.ts
+++ b/applications/launchpad_v2/src/types/general.ts
@@ -1,0 +1,14 @@
+import { CSSProperties } from 'react'
+import { SpringValue } from 'react-spring'
+
+export type CoinType = 'xtr' | ' xmr'
+
+export type MiningNodeType = 'tari' | 'merged'
+
+/**
+ * Style types
+ */
+export type CSSWithSpring =
+  | CSSProperties
+  | Record<string, SpringValue<number>>
+  | Record<string, SpringValue<string>>


### PR DESCRIPTION
Description
---
The mining dashboard.

The PR introduces the `MiningBox` container - it is a generic component that by default provides generic statuses, styling, UI and actions + selectors. So to add any mining node, just import this component and provide the node name/type: `<MiningBox node='tari' />`. Then, the container will observe specific place in global store (Redux) to display data, and implements basic actions using thunks, like start-stop container.

The MiningBox container can be in one of few statuses, ie: `running`, `paused`, `blocked` etc.

UI styling and what is rendered for a specific status, can be controlled by the parent component with two props:
- `statuses` - provides styling,
- `children` - if parent needs to render custom content in the box.

Motivation and Context
---

Base layout for Tari mining #12 
Base layout for Merge mining #13 

How Has This Been Tested?
---

https://user-images.githubusercontent.com/11715931/166238916-e618506b-81a7-4f7f-99d4-1be2e9f7f5e5.mov


https://user-images.githubusercontent.com/11715931/166239052-0dfea2d8-ed4c-4d31-9bea-030f5667d2dd.mov


