### PR TITLE
fix: tag component background styling, app.tsx typo

### DIFF
--- a/applications/launchpad_v2/src/App.tsx
+++ b/applications/launchpad_v2/src/App.tsx
@@ -12,7 +12,7 @@ const AppContainer = styled.div`
   display: flex;
   flex: 1;
   overflow: hidden;
-  borderradius: 10;
+  border-radius: 10;
 `
 
 const App = () => {

--- a/applications/launchpad_v2/src/components/Tag/index.tsx
+++ b/applications/launchpad_v2/src/components/Tag/index.tsx
@@ -79,7 +79,11 @@ const Tag = ({
 
   const tagContent = (
     <>
-      {icon && <IconWrapper style={baseStyle}>{icon}</IconWrapper>}
+      {icon && (
+        <IconWrapper type={type} textStyle={textStyle}>
+          {icon}
+        </IconWrapper>
+      )}
 
       <Text
         type={variant === 'large' ? 'smallHeavy' : 'microMedium'}

--- a/applications/launchpad_v2/src/components/Tag/styles.ts
+++ b/applications/launchpad_v2/src/components/Tag/styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled, { CSSProperties } from 'styled-components'
 
 export const TagContainer = styled.div<{ variant?: string }>`
   display: flex;
@@ -13,10 +13,16 @@ export const TagContainer = styled.div<{ variant?: string }>`
   padding-right: 12px;
 `
 
-export const IconWrapper = styled.div`
+export const IconWrapper = styled.div<{
+  type?: string
+  textStyle?: CSSProperties
+  baseStyle?: CSSProperties
+}>`
   display: flex;
   align-items: center;
   color: white;
   height: 100%;
   margin-right: 7.5px;
+  color: ${({ theme, type, textStyle }) =>
+    type === 'expert' ? theme.accent : textStyle?.color};
 `


### PR DESCRIPTION
Description
---
- Fixing background styling of Tag component `expert` type (incorrect background colour around icon)
- Found styling typo inside `App.tsx`

Motivation and Context
---
#117 

How Has This Been Tested?
---
<img width="314" alt="Screenshot 2022-05-02 at 09 41 11" src="https://user-images.githubusercontent.com/69508715/166201520-cc5a1c43-768f-41f9-90fb-90821e305a3b.png">

