### PR TITLE
feat(wallet settings): add user feedback to CopyBox

### DIFF
--- a/.github/workflows/launchpad_v2_audit.yml
+++ b/.github/workflows/launchpad_v2_audit.yml
@@ -16,7 +16,7 @@ jobs:
           node -v
           npm -v
           yarn -v
-      - name: npm audit launchpad_v2
+      - name: npm audit launchpad/gui-react
         run: |
           cd applications/launchpad/gui-react
           yarn audit

--- a/applications/launchpad/gui-react/src/components/CopyBox/index.tsx
+++ b/applications/launchpad/gui-react/src/components/CopyBox/index.tsx
@@ -1,13 +1,17 @@
+import { useState, useEffect, useRef } from 'react'
 import { clipboard } from '@tauri-apps/api'
+import { useSpring, animated } from 'react-spring'
 
 import Button from '../Button'
 import Text from '../Text'
+import Tag from '../Tag'
 import CopyIcon from '../../styles/Icons/Copy'
+import t from '../../locales'
 
-import { StyledBox } from './styles'
+import { StyledBox, FeedbackContainer } from './styles'
 
 /**
- * @name CopyBoc
+ * @name CopyBox
  * @description Renders a box with value with a button that allows to copy it
  *
  *
@@ -15,18 +19,49 @@ import { StyledBox } from './styles'
  * @prop {string} value - value that can be copied to clipboard
  */
 const CopyBox = ({ label, value }: { label: string; value: string }) => {
+  const [copied, setCopied] = useState(false)
+  const styles = useSpring({ opacity: copied ? 1 : 0 })
+  const timeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
   const copy = async () => {
     await clipboard.writeText(value)
 
-    alert(`copied ${value}`)
+    setCopied(true)
+    if (timeout.current) {
+      clearTimeout(timeout.current)
+    }
+
+    timeout.current = setTimeout(() => {
+      setCopied(false)
+      timeout.current = undefined
+    }, 2000)
   }
+
+  useEffect(() => {
+    return () => {
+      if (timeout.current) {
+        clearTimeout(timeout.current)
+      }
+    }
+  }, [])
 
   return (
     <>
       <Text>{label}</Text>
       <StyledBox>
         {value}
-        <Button variant='text' style={{ padding: 0, margin: 0 }} onClick={copy}>
+        <Button
+          variant='text'
+          style={{ padding: 0, margin: 0, position: 'relative' }}
+          onClick={copy}
+        >
+          <FeedbackContainer>
+            <animated.div style={styles}>
+              <Tag type='info' variant='small'>
+                {t.common.adjectives.copied}!
+              </Tag>
+            </animated.div>
+          </FeedbackContainer>
           <CopyIcon />
         </Button>
       </StyledBox>

--- a/applications/launchpad/gui-react/src/components/CopyBox/styles.ts
+++ b/applications/launchpad/gui-react/src/components/CopyBox/styles.ts
@@ -12,3 +12,10 @@ export const StyledBox = styled.span`
   display: flex;
   justify-content: space-between;
 `
+
+export const FeedbackContainer = styled.div`
+  position: absolute;
+  left: 50%;
+  bottom: 120%;
+  transform: translateX(-50%);
+`

--- a/applications/launchpad/gui-react/src/locales/common.ts
+++ b/applications/launchpad/gui-react/src/locales/common.ts
@@ -17,6 +17,7 @@ const translations: { [key: string]: { [key: string]: string } } = {
   adjectives: {
     running: 'Running',
     paused: 'Paused',
+    copied: 'Copied',
   },
   phrases: {
     actionRequired: 'Action required',


### PR DESCRIPTION
Description
---
added self-hiding tooltip to CopyBox when user copies the value by clicking "copy" icon

Motivation and Context
---

#124 #26 

How Has This Been Tested?
---

![copied](https://user-images.githubusercontent.com/9142942/166671325-7513eaf8-ad50-4419-8b92-f634bb561e89.gif)

