### PR TITLE
feat: base node starts and stops required docker services

### DIFF
--- a/applications/launchpad/gui-react/src/App.tsx
+++ b/applications/launchpad/gui-react/src/App.tsx
@@ -1,10 +1,15 @@
-import { useSelector } from 'react-redux'
+import { useEffect } from 'react'
+import { invoke } from '@tauri-apps/api/tauri'
+import { listen } from '@tauri-apps/api/event'
 import styled, { ThemeProvider } from 'styled-components'
 
 import { selectThemeConfig } from './store/app/selectors'
+import { actions } from './store/services'
+import { Service } from './store/services/types'
+import { useAppSelector, useAppDispatch } from './store/hooks'
 
 import HomePage from './pages/home'
-
+import { loadDefaultServiceSettings } from './store/settings/thunks'
 import './styles/App.css'
 
 const AppContainer = styled.div`
@@ -14,13 +19,53 @@ const AppContainer = styled.div`
   overflow: hidden;
   border-radius: 10;
 `
-
 const App = () => {
-  const themeConfig = useSelector(selectThemeConfig)
+  const themeConfig = useAppSelector(selectThemeConfig)
+  const dispatch = useAppDispatch()
+  dispatch(loadDefaultServiceSettings())
+
+  useEffect(() => {
+    invoke('events')
+  }, [])
+
+  useEffect(() => {
+    let unsubscribe
+
+    const listenToSystemEvents = async () => {
+      unsubscribe = await listen('tari://docker-system-event', event => {
+        console.log('System event: ', event.payload)
+      })
+    }
+
+    // listenToSystemEvents()
+
+    return unsubscribe
+  }, [])
+
+  const launch = async (service: Service) => {
+    dispatch(actions.start(service))
+  }
+
+  const magic = async () => {
+    await launch(Service.Tor)
+    await launch(Service.BaseNode)
+  }
 
   return (
     <ThemeProvider theme={themeConfig}>
       <AppContainer>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <button onClick={() => launch(Service.Tor)}>tor</button>
+          <button onClick={() => launch(Service.BaseNode)}>base_node</button>
+          <button onClick={magic}>magic</button>
+        </div>
         <HomePage />
       </AppContainer>
     </ThemeProvider>

--- a/applications/launchpad/gui-react/src/App.tsx
+++ b/applications/launchpad/gui-react/src/App.tsx
@@ -3,10 +3,8 @@ import { invoke } from '@tauri-apps/api/tauri'
 import { listen } from '@tauri-apps/api/event'
 import styled, { ThemeProvider } from 'styled-components'
 
-import { selectThemeConfig } from './store/app/selectors'
-import { actions } from './store/services'
-import { Service } from './store/services/types'
 import { useAppSelector, useAppDispatch } from './store/hooks'
+import { selectThemeConfig } from './store/app/selectors'
 
 import HomePage from './pages/home'
 import { loadDefaultServiceSettings } from './store/settings/thunks'
@@ -37,35 +35,14 @@ const App = () => {
       })
     }
 
-    // listenToSystemEvents()
+    listenToSystemEvents()
 
     return unsubscribe
   }, [])
 
-  const launch = async (service: Service) => {
-    dispatch(actions.start(service))
-  }
-
-  const magic = async () => {
-    await launch(Service.Tor)
-    await launch(Service.BaseNode)
-  }
-
   return (
     <ThemeProvider theme={themeConfig}>
       <AppContainer>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          <button onClick={() => launch(Service.Tor)}>tor</button>
-          <button onClick={() => launch(Service.BaseNode)}>base_node</button>
-          <button onClick={magic}>magic</button>
-        </div>
         <HomePage />
       </AppContainer>
     </ThemeProvider>

--- a/applications/launchpad/gui-react/src/containers/BaseNodeContainer/BaseNode.tsx
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeContainer/BaseNode.tsx
@@ -10,7 +10,7 @@ import t from '../../locales'
 
 import { BaseNodeProps, Network } from './types'
 
-const networks = ['mainnet', 'testnet']
+const networks = ['dibbler', 'testnet']
 const networkOptions = networks.map(network => ({
   label: network,
   value: network,

--- a/applications/launchpad/gui-react/src/containers/BaseNodeContainer/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeContainer/index.tsx
@@ -1,11 +1,12 @@
 import { useAppSelector, useAppDispatch } from '../../store/hooks'
-import { selectState } from '../../store/baseNode/selectors'
+import { selectState, selectStatus } from '../../store/baseNode/selectors'
 import { actions } from '../../store/baseNode'
 
 import BaseNode from './BaseNode'
 
 const BaseNodeContainer = () => {
-  const { network, running, pending } = useAppSelector(selectState)
+  const { network } = useAppSelector(selectState)
+  const { running, pending } = useAppSelector(selectStatus)
   const dispatch = useAppDispatch()
 
   return (

--- a/applications/launchpad/gui-react/src/containers/BaseNodeContainer/types.ts
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeContainer/types.ts
@@ -1,4 +1,4 @@
-export type Network = 'mainnet' | 'testnet'
+export type Network = 'dibbler' | 'testnet'
 
 export interface BaseNodeProps {
   startNode: () => void

--- a/applications/launchpad/gui-react/src/containers/Dashboard/DashboardContainer/components/DashboardTabs/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/DashboardContainer/components/DashboardTabs/index.tsx
@@ -8,8 +8,12 @@ import Tag from '../../../../../components/Tag'
 import { setPage } from '../../../../../store/app'
 import { ViewType } from '../../../../../store/app/types'
 import { selectView } from '../../../../../store/app/selectors'
-import { selectState as selectBaseNodeState } from '../../../../../store/baseNode/selectors'
+import {
+  selectState as selectBaseNodeState,
+  selectStatus as selectBaseNodeStatus,
+} from '../../../../../store/baseNode/selectors'
 import { BaseNodeState } from '../../../../../store/baseNode/types'
+import { ServiceStatus } from '../../../../../store/services/types'
 import { selectState as selectWalletState } from '../../../../../store/wallet/selectors'
 import { WalletState } from '../../../../../store/wallet/types'
 
@@ -59,7 +63,7 @@ const composeNodeTabs = ({
   walletState,
 }: {
   miningNodeState?: unknown
-  baseNodeState?: BaseNodeState
+  baseNodeState: BaseNodeState & ServiceStatus
   walletState?: WalletState
 }) => {
   const miningContent = <TabContent text={t.common.nouns.mining} />
@@ -110,13 +114,14 @@ const DashboardTabs = () => {
 
   const currentPage = useSelector(selectView)
   const baseNodeState = useSelector(selectBaseNodeState)
+  const baseNodeStatus = useSelector(selectBaseNodeStatus)
   const walletState = useSelector(selectWalletState)
 
   const tabs = useMemo(
     () =>
       composeNodeTabs({
         miningNodeState: undefined,
-        baseNodeState,
+        baseNodeState: { ...baseNodeStatus, ...baseNodeState },
         walletState,
       }),
     [walletState, baseNodeState],

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/index.tsx
@@ -1,10 +1,12 @@
-import { useDispatch, useSelector } from 'react-redux'
+import { useAppDispatch, useAppSelector } from '../../../store/hooks'
 import { setExpertView } from '../../../store/app'
 import { selectExpertView } from '../../../store/app/selectors'
+import { selectState } from '../../../store/services/selectors'
 
 const ExpertView = () => {
-  const dispatch = useDispatch()
-  const expertView = useSelector(selectExpertView)
+  const dispatch = useAppDispatch()
+  const expertView = useAppSelector(selectExpertView)
+  const servicesState = useAppSelector(selectState)
 
   return (
     <div>
@@ -18,6 +20,9 @@ const ExpertView = () => {
       >
         Fullscreen
       </button>
+      <pre style={{ color: 'white' }}>
+        {JSON.stringify(servicesState, null, 2)}
+      </pre>
     </div>
   )
 }

--- a/applications/launchpad/gui-react/src/store/app/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/app/thunks.ts
@@ -1,1 +1,0 @@
-export const module = {}

--- a/applications/launchpad/gui-react/src/store/baseNode/index.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/index.ts
@@ -1,13 +1,10 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-import { BaseNodeState } from './types'
 import { startNode, stopNode } from './thunks'
 import { Network } from '../../containers/BaseNodeContainer/types'
 
-const initialState: BaseNodeState = {
-  network: 'mainnet',
-  running: false,
-  pending: false,
+const initialState = {
+  network: 'dibbler',
 }
 
 const baseNodeSlice = createSlice({
@@ -16,22 +13,6 @@ const baseNodeSlice = createSlice({
   reducers: {
     setTariNetwork(state, action: PayloadAction<Network>) {
       state.network = action.payload
-    },
-  },
-  extraReducers: {
-    [`${startNode.pending}`]: (state: BaseNodeState) => {
-      state.pending = true
-    },
-    [`${startNode.fulfilled}`]: (state: BaseNodeState) => {
-      state.running = true
-      state.pending = false
-    },
-    [`${stopNode.pending}`]: (state: BaseNodeState) => {
-      state.pending = true
-    },
-    [`${stopNode.fulfilled}`]: (state: BaseNodeState) => {
-      state.running = false
-      state.pending = false
     },
   },
 })

--- a/applications/launchpad/gui-react/src/store/baseNode/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/selectors.ts
@@ -1,3 +1,12 @@
 import { RootState } from '../'
+import { Service } from '../services/types'
+import { selectServiceStatus } from '../services/selectors'
+import type { Network } from '../../containers/BaseNodeContainer/types'
 
-export const selectState = (state: RootState) => state.baseNode
+import { BaseNodeState } from './types'
+
+export const selectState = (state: RootState): BaseNodeState => ({
+  network: state.baseNode.network as Network,
+})
+
+export const selectStatus = selectServiceStatus(Service.BaseNode)

--- a/applications/launchpad/gui-react/src/store/baseNode/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/thunks.ts
@@ -1,20 +1,36 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
+
 import { RootState } from '..'
+import { selectServiceStatus } from '../services/selectors'
+import { actions as servicesActions } from '../services'
+import { Service } from '../services/types'
 
-export const startNode = createAsyncThunk('startNode', async (_, thunkAPI) => {
-  const {
-    baseNode: { network },
-  } = thunkAPI.getState() as RootState
+export const startNode = createAsyncThunk<void, void, { state: RootState }>(
+  'baseNode/startNode',
+  async (_, thunkApi) => {
+    try {
+      const rootState = thunkApi.getState()
+      const torStatus = selectServiceStatus(Service.Tor)(rootState)
 
-  console.log(`starting base node on network ${network}`)
-  await new Promise(resolve => setTimeout(resolve, 2000))
-})
+      if (!torStatus.running && !torStatus.pending) {
+        await thunkApi.dispatch(servicesActions.start(Service.Tor)).unwrap()
+      }
 
-export const stopNode = createAsyncThunk('stopNode', async (_, thunkAPI) => {
-  const {
-    baseNode: { network },
-  } = thunkAPI.getState() as RootState
+      await thunkApi.dispatch(servicesActions.start(Service.BaseNode)).unwrap()
+    } catch (e) {
+      return thunkApi.rejectWithValue(e)
+    }
+  },
+)
 
-  console.log(`stopping base node on network ${network}`)
-  await new Promise(resolve => setTimeout(resolve, 2000))
-})
+export const stopNode = createAsyncThunk<void, void>(
+  'baseNode/stopNode',
+  async (_, thunkApi) => {
+    try {
+      await thunkApi.dispatch(servicesActions.stop(Service.BaseNode)).unwrap()
+      await thunkApi.dispatch(servicesActions.stop(Service.Tor)).unwrap()
+    } catch (e) {
+      return thunkApi.rejectWithValue(e)
+    }
+  },
+)

--- a/applications/launchpad/gui-react/src/store/baseNode/types.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/types.ts
@@ -2,6 +2,4 @@ import type { Network } from '../../containers/BaseNodeContainer/types'
 
 export type BaseNodeState = {
   network: Network
-  running: boolean
-  pending: boolean
 }

--- a/applications/launchpad/gui-react/src/store/index.ts
+++ b/applications/launchpad/gui-react/src/store/index.ts
@@ -5,6 +5,7 @@ import settingsReducer from './settings'
 import baseNodeReducer from './baseNode'
 import miningReducer from './mining'
 import walletReducer from './wallet'
+import servicesReducer from './services'
 
 // exported for tests
 export const rootReducer = {
@@ -13,6 +14,7 @@ export const rootReducer = {
   mining: miningReducer,
   wallet: walletReducer,
   settings: settingsReducer,
+  services: servicesReducer,
 }
 
 export const store = configureStore({

--- a/applications/launchpad/gui-react/src/store/services/index.ts
+++ b/applications/launchpad/gui-react/src/store/services/index.ts
@@ -1,7 +1,7 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { createSlice } from '@reduxjs/toolkit'
 
-import { ServiceDescriptor, ServicesState, Service } from './types'
-import { start } from './thunks'
+import { ServicesState, Service } from './types'
+import { start, stop } from './thunks'
 
 export const initialState: ServicesState = {
   services: {},
@@ -40,24 +40,41 @@ const servicesSlice = createSlice({
   reducers: {},
   extraReducers: builder => {
     builder.addCase(start.pending, (state, { meta }) => {
-      console.log('pending', meta.arg)
       state.servicesStatus[meta.arg].pending = true
-      state.servicesStatus[meta.arg].error = ''
+      state.servicesStatus[meta.arg].error = undefined
     })
     builder.addCase(start.fulfilled, (state, action) => {
       state.servicesStatus[action.payload.service].pending = false
+      state.servicesStatus[action.payload.service].running = true
       state.servicesStatus[action.payload.service].id =
         action.payload.descriptor.id
-
-      console.log(action.payload)
     })
     builder.addCase(start.rejected, (state, action) => {
-      console.log('ERROR STARING')
+      state.servicesStatus[action.meta.arg].pending = false
+      state.servicesStatus[action.meta.arg].running = false
+      state.servicesStatus[action.meta.arg].error = action.error.message
+      console.log(`ERROR STARTING SERVICE ${action.meta.arg}`)
+      console.log(action.error)
+    })
+
+    builder.addCase(stop.pending, (state, { meta }) => {
+      state.servicesStatus[meta.arg].pending = true
+      state.servicesStatus[meta.arg].error = undefined
+    })
+    builder.addCase(stop.fulfilled, (state, action) => {
+      state.servicesStatus[action.meta.arg].pending = false
+      state.servicesStatus[action.meta.arg].running = false
+    })
+    builder.addCase(stop.rejected, (state, action) => {
+      state.servicesStatus[action.meta.arg].pending = false
+      state.servicesStatus[action.meta.arg].running = false
+      state.servicesStatus[action.meta.arg].error = action.error.message
+      console.log(`ERROR STOPPING SERVICE ${action.meta.arg}`)
       console.log(action.error)
     })
   },
 })
 
-export const actions = { start }
+export const actions = { start, stop }
 
 export default servicesSlice.reducer

--- a/applications/launchpad/gui-react/src/store/services/index.ts
+++ b/applications/launchpad/gui-react/src/store/services/index.ts
@@ -1,0 +1,63 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+import { ServiceDescriptor, ServicesState, Service } from './types'
+import { start } from './thunks'
+
+export const initialState: ServicesState = {
+  services: {},
+  servicesStatus: {
+    [Service.Tor]: {
+      id: '',
+      pending: false,
+      running: false,
+    },
+    [Service.BaseNode]: {
+      id: '',
+      pending: false,
+      running: false,
+    },
+    [Service.Wallet]: {
+      id: '',
+      pending: false,
+      running: false,
+    },
+    [Service.SHA3Miner]: {
+      id: '',
+      pending: false,
+      running: false,
+    },
+    [Service.MMProxy]: {
+      id: '',
+      pending: false,
+      running: false,
+    },
+  },
+}
+
+const servicesSlice = createSlice({
+  name: 'services',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(start.pending, (state, { meta }) => {
+      console.log('pending', meta.arg)
+      state.servicesStatus[meta.arg].pending = true
+      state.servicesStatus[meta.arg].error = ''
+    })
+    builder.addCase(start.fulfilled, (state, action) => {
+      state.servicesStatus[action.payload.service].pending = false
+      state.servicesStatus[action.payload.service].id =
+        action.payload.descriptor.id
+
+      console.log(action.payload)
+    })
+    builder.addCase(start.rejected, (state, action) => {
+      console.log('ERROR STARING')
+      console.log(action.error)
+    })
+  },
+})
+
+export const actions = { start }
+
+export default servicesSlice.reducer

--- a/applications/launchpad/gui-react/src/store/services/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/services/selectors.ts
@@ -8,3 +8,8 @@ export const selectServiceStatus =
   (service: Service) =>
   (rootState: RootState): ServiceStatus =>
     rootState.services.servicesStatus[service]
+
+export const selectRunningServices = (rootState: RootState): Service[] =>
+  Object.entries(rootState.services.servicesStatus)
+    .filter(([, status]) => status.running)
+    .map(([service]) => service as Service)

--- a/applications/launchpad/gui-react/src/store/services/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/services/selectors.ts
@@ -1,0 +1,10 @@
+import { RootState } from '../'
+
+import { Service, ServiceStatus } from './types'
+
+export const selectState = (rootState: RootState) => rootState.services
+
+export const selectServiceStatus =
+  (service: Service) =>
+  (rootState: RootState): ServiceStatus =>
+    rootState.services.servicesStatus[service]

--- a/applications/launchpad/gui-react/src/store/services/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/services/thunks.ts
@@ -2,6 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit'
 import { invoke } from '@tauri-apps/api/tauri'
 
 import type { RootState } from '../'
+import { selectServiceSettings } from '../settings/selectors'
 
 import { Service, ServiceDescriptor } from './types'
 
@@ -12,10 +13,11 @@ export const start = createAsyncThunk<
 >('services/start', async (service, thunkAPI) => {
   try {
     const rootState = thunkAPI.getState()
+    const settings = selectServiceSettings(rootState)
 
     const descriptor: ServiceDescriptor = await invoke('start_service', {
       serviceName: service.toString(),
-      settings: rootState.settings.serviceSettings,
+      settings,
     })
 
     return {
@@ -26,3 +28,16 @@ export const start = createAsyncThunk<
     return thunkAPI.rejectWithValue(error)
   }
 })
+
+export const stop = createAsyncThunk<void, Service>(
+  'services/stop',
+  async (service, thunkAPI) => {
+    try {
+      await invoke('stop_service', {
+        serviceName: service.toString(),
+      })
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error)
+    }
+  },
+)

--- a/applications/launchpad/gui-react/src/store/services/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/services/thunks.ts
@@ -1,0 +1,28 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { invoke } from '@tauri-apps/api/tauri'
+
+import type { RootState } from '../'
+
+import { Service, ServiceDescriptor } from './types'
+
+export const start = createAsyncThunk<
+  { service: Service; descriptor: ServiceDescriptor },
+  Service,
+  { state: RootState }
+>('services/start', async (service, thunkAPI) => {
+  try {
+    const rootState = thunkAPI.getState()
+
+    const descriptor: ServiceDescriptor = await invoke('start_service', {
+      serviceName: service.toString(),
+      settings: rootState.settings.serviceSettings,
+    })
+
+    return {
+      service,
+      descriptor,
+    }
+  } catch (error) {
+    return thunkAPI.rejectWithValue(error)
+  }
+})

--- a/applications/launchpad/gui-react/src/store/services/types.ts
+++ b/applications/launchpad/gui-react/src/store/services/types.ts
@@ -1,0 +1,28 @@
+export enum Service {
+  Tor = 'tor',
+  BaseNode = 'base_node',
+  Wallet = 'wallet',
+  SHA3Miner = 'sha3_miner',
+  MMProxy = 'mm_proxy',
+}
+
+type ServiceId = string
+
+export type ServiceDescriptor = {
+  id: ServiceId
+  logEventsName: string
+  statsEventsName: string
+  name: string
+}
+
+export type ServiceStatus = {
+  id: ServiceId
+  pending: boolean
+  running: boolean
+  error?: string
+}
+
+export type ServicesState = {
+  services: Record<string, unknown>
+  servicesStatus: Record<Service, ServiceStatus>
+}

--- a/applications/launchpad/gui-react/src/store/settings/index.ts
+++ b/applications/launchpad/gui-react/src/store/settings/index.ts
@@ -1,10 +1,12 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
 import { SettingsState, Settings } from './types'
+import { loadDefaultServiceSettings } from './thunks'
 
 export const initialState: SettingsState = {
   open: false,
   which: Settings.Mining,
+  serviceSettings: {},
 }
 
 const settingsSlice = createSlice({
@@ -25,8 +27,18 @@ const settingsSlice = createSlice({
       state.which = action.payload
     },
   },
+  extraReducers: builder => {
+    builder.addCase(loadDefaultServiceSettings.fulfilled, (state, action) => {
+      state.serviceSettings = action.payload
+    })
+  },
 })
 
-export const { actions } = settingsSlice
+const { actions: syncActions } = settingsSlice
+
+export const actions = {
+  ...syncActions,
+  loadDefaultServiceSettings,
+}
 
 export default settingsSlice.reducer

--- a/applications/launchpad/gui-react/src/store/settings/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/settings/selectors.ts
@@ -1,4 +1,17 @@
+import { sep } from '@tauri-apps/api/path'
+
 import { RootState } from '../'
 
 export const selectSettingsOpen = (state: RootState) => state.settings.open
 export const selectActiveSettings = (state: RootState) => state.settings.which
+export const selectServiceSettings = (state: RootState) => ({
+  ...state.settings.serviceSettings,
+  tariNetwork: state.baseNode.network,
+  rootFolder:
+    state.settings.serviceSettings.cacheDir +
+    'tari' +
+    sep +
+    'tmp' +
+    sep +
+    state.baseNode.network,
+})

--- a/applications/launchpad/gui-react/src/store/settings/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/settings/thunks.ts
@@ -1,0 +1,23 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { cacheDir, sep } from '@tauri-apps/api/path'
+
+const getSettings = async () => ({
+  walletPassword: 'tari',
+  moneroMiningAddress:
+    '5AJ8FwQge4UjT9Gbj4zn7yYcnpVQzzkqr636pKto59jQcu85CFsuYVeFgbhUdRpiPjUCkA4sQtWApUzCyTMmSigFG2hDo48',
+  numMiningThreads: 1,
+  tariNetwork: 'dibbler',
+  rootFolder: (await cacheDir()) + 'tari' + sep + 'tmp' + sep + 'dibbler',
+  dockerRegistry: 'quay.io/tarilabs',
+  dockerTag: 'latest',
+  monerodUrl:
+    'http://stagenet.community.xmr.to:38081,http://monero-stagenet.exan.tech:3808',
+  moneroUseAuth: false,
+  moneroUsername: '',
+  moneroPassword: '',
+})
+
+export const loadDefaultServiceSettings = createAsyncThunk<unknown>(
+  'service/start',
+  getSettings,
+)

--- a/applications/launchpad/gui-react/src/store/settings/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/settings/thunks.ts
@@ -7,7 +7,7 @@ const getSettings = async () => ({
     '5AJ8FwQge4UjT9Gbj4zn7yYcnpVQzzkqr636pKto59jQcu85CFsuYVeFgbhUdRpiPjUCkA4sQtWApUzCyTMmSigFG2hDo48',
   numMiningThreads: 1,
   tariNetwork: 'dibbler',
-  rootFolder: (await cacheDir()) + 'tari' + sep + 'tmp' + sep + 'dibbler',
+  cacheDir: await cacheDir(),
   dockerRegistry: 'quay.io/tarilabs',
   dockerTag: 'latest',
   monerodUrl:

--- a/applications/launchpad/gui-react/src/store/settings/types.ts
+++ b/applications/launchpad/gui-react/src/store/settings/types.ts
@@ -10,4 +10,5 @@ export enum Settings {
 export type SettingsState = {
   open: boolean
   which: Settings
+  serviceSettings: unknown
 }

--- a/applications/launchpad/gui-react/src/store/settings/types.ts
+++ b/applications/launchpad/gui-react/src/store/settings/types.ts
@@ -10,5 +10,5 @@ export enum Settings {
 export type SettingsState = {
   open: boolean
   which: Settings
-  serviceSettings: unknown
+  serviceSettings: any
 }


### PR DESCRIPTION
Description
---
prerequisites:
build docker images with `applications/launchpad/build_images.sh`

starting base node now starts tor(if necessary) and base node containers!
stopping base node from app stops the container and tor if it's the last service running

it all works on settings hardcoded in the store, for now

Motivation and Context
---

#61 
kind of related to #7 ^^

How Has This Been Tested?
---

![running](https://user-images.githubusercontent.com/9142942/166889687-69f03fa3-98b3-43da-86bf-4b4fad52d640.gif)
