### PR TITLE
fix: dashboard tab styling

### DIFF
--- a/applications/launchpad/gui-react/src/components/Tabs/index.tsx
+++ b/applications/launchpad/gui-react/src/components/Tabs/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useSpring } from 'react-spring'
+import { useTheme } from 'styled-components'
 
 import Text from '../Text'
 
@@ -11,6 +12,7 @@ import {
   TabSelectedBorder,
   FontWeightCompensation,
 } from './styles'
+
 import { TabsProps } from './types'
 
 /**
@@ -37,6 +39,7 @@ const Tabs = ({ tabs, selected, onSelect }: TabsProps) => {
   // Also, the Tabs component needs to re-render tabs twice on the initial mount,
   // because the selected tab uses bold font, which changes tabs widths.
   const [initialized, setInitialzed] = useState(0)
+  const theme = useTheme()
 
   useEffect(() => {
     tabsRefs.current = tabsRefs.current.slice(0, tabs.length)
@@ -53,6 +56,7 @@ const Tabs = ({ tabs, selected, onSelect }: TabsProps) => {
   let width = 0
   let left = 0
   let totalWidth = 0
+  const tabMargin = theme.tabsMarginRight
 
   if (selectedIndex > -1) {
     if (
@@ -63,7 +67,7 @@ const Tabs = ({ tabs, selected, onSelect }: TabsProps) => {
       tabsRefs.current.forEach((el, index) => {
         if (el) {
           if (index < selectedIndex) {
-            left = left + el.offsetWidth
+            left = left + el.offsetWidth + tabMargin
           } else if (index === selectedIndex) {
             width = el.offsetWidth
           }

--- a/applications/launchpad/gui-react/src/components/Tabs/index.tsx
+++ b/applications/launchpad/gui-react/src/components/Tabs/index.tsx
@@ -90,6 +90,8 @@ const Tabs = ({ tabs, selected, onSelect }: TabsProps) => {
             key={`tab-${index}`}
             ref={el => (tabsRefs.current[index] = el)}
             onClick={() => onSelect(tab.id)}
+            selected={selected}
+            tab={tab}
           >
             <FontWeightCompensation>
               <Text

--- a/applications/launchpad/gui-react/src/components/Tabs/styles.ts
+++ b/applications/launchpad/gui-react/src/components/Tabs/styles.ts
@@ -20,6 +20,7 @@ export const Tab = styled.button`
   box-shadow: none;
   border-width: 0px;
   border-bottom: 4px solid transparent;
+  border-radius: ${({ theme }) => theme.tightBorderRadius(1.5)};
   background: transparent;
   box-sizing: border-box;
   margin: 0px;
@@ -27,6 +28,10 @@ export const Tab = styled.button`
   position: relative;
   cursor: pointer;
   align-items: center;
+  transition: ease-in-out 300ms;
+  &:hover {
+    background-color: ${({ theme }) => theme.backgroundSecondary};
+  }
 `
 
 export const TabSelectedBorder = styled(animated.div)`

--- a/applications/launchpad/gui-react/src/components/Tabs/styles.ts
+++ b/applications/launchpad/gui-react/src/components/Tabs/styles.ts
@@ -23,6 +23,7 @@ export const Tab = styled.button`
   background: transparent;
   box-sizing: border-box;
   margin: 0px;
+  margin-right: ${({ theme }) => `${theme.tabsMarginRight}`}px;
   position: relative;
   cursor: pointer;
   align-items: center;

--- a/applications/launchpad/gui-react/src/components/Tabs/styles.ts
+++ b/applications/launchpad/gui-react/src/components/Tabs/styles.ts
@@ -1,3 +1,4 @@
+import { TabProp } from './types'
 import { animated } from 'react-spring'
 import styled from 'styled-components'
 
@@ -14,13 +15,17 @@ export const TabOptions = styled.div`
   align-items: center;
 `
 
-export const Tab = styled.button`
+export const Tab = styled.button<{ selected?: string; tab?: TabProp }>`
   display: flex;
   padding: 8px 12px;
   box-shadow: none;
   border-width: 0px;
   border-bottom: 4px solid transparent;
   border-radius: ${({ theme }) => theme.tightBorderRadius(1.5)};
+  border-bottom-left-radius: ${({ theme, selected, tab }) =>
+    selected === tab?.id ? 0 : theme.tightBorderRadius(1.5)};
+  border-bottom-right-radius: ${({ theme, selected, tab }) =>
+    selected === tab?.id ? 0 : theme.tightBorderRadius(1.5)};
   background: transparent;
   box-sizing: border-box;
   margin: 0px;
@@ -31,6 +36,9 @@ export const Tab = styled.button`
   transition: ease-in-out 300ms;
   &:hover {
     background-color: ${({ theme }) => theme.backgroundSecondary};
+  }
+  &:last-child {
+    margin-right: 0;
   }
 `
 

--- a/applications/launchpad/gui-react/src/custom.d.ts
+++ b/applications/launchpad/gui-react/src/custom.d.ts
@@ -15,6 +15,7 @@ declare module 'styled-components' {
     spacingVertical: (count?: number) => string
     borderRadius: (count?: number) => string
     tightBorderRadius: (count?: number) => string
+    tabsMarginRight: number
     primary: string
     secondary: string
     tertiary: string

--- a/applications/launchpad/gui-react/src/styles/themes/index.ts
+++ b/applications/launchpad/gui-react/src/styles/themes/index.ts
@@ -13,6 +13,7 @@ const withShared = (theme: Record<string, unknown>): DefaultTheme =>
     spacing: (count = 1) => `${count * SPACING}px`,
     spacingVertical: (count = 1) => `${count * (0.54 * SPACING)}px`,
     spacingHorizontal: (count = 1) => `${count * SPACING}px`,
+    tabsMarginRight: 32,
   } as DefaultTheme)
 
 const themes = {


### PR DESCRIPTION
Description
---
- Adjusting dashboard tabs to have correct horizontal margin.
- Adding hover state styling to dashboard tabs (it's _really_ subtle but that's the design from Figma)

Motivation and Context
---
#132

How Has This Been Tested?
---
Figma:


https://user-images.githubusercontent.com/69508715/166886895-4cb0e7cd-e27c-4cdd-9615-f4f2b5df899c.mov

App:


https://user-images.githubusercontent.com/69508715/166890479-18765974-6b84-48e7-9199-4adf2eb92f5a.mov