### PR TITLE
fix: label should use AvenirMedium font-family

### DIFF
--- a/applications/launchpad/gui-react/src/components/Inputs/Input/index.tsx
+++ b/applications/launchpad/gui-react/src/components/Inputs/Input/index.tsx
@@ -28,6 +28,7 @@ import { ChangeEvent, forwardRef } from 'react'
 
 const Input = (
   {
+    autoFocus,
     type = 'text',
     value,
     disabled,
@@ -50,6 +51,7 @@ const Input = (
   return (
     <InputContainer disabled={disabled} style={containerStyle}>
       <StyledInput
+        autoFocus={autoFocus}
         type={type}
         placeholder={placeholder}
         disabled={disabled}

--- a/applications/launchpad/gui-react/src/components/Inputs/Input/styles.ts
+++ b/applications/launchpad/gui-react/src/components/Inputs/Input/styles.ts
@@ -1,12 +1,10 @@
 /* eslint-disable indent */
+import { InputHTMLAttributes } from 'react'
 import styled from 'styled-components'
+
 import Text from '../../Text'
 
-export const StyledInput = styled.input<{
-  type?: string
-  disabled?: boolean
-  value?: string
-}>`
+export const StyledInput = styled.input<InputHTMLAttributes<HTMLInputElement>>`
   height: 100%;
   width: 100%;
   padding: 0px 16px;

--- a/applications/launchpad/gui-react/src/components/Inputs/Input/types.ts
+++ b/applications/launchpad/gui-react/src/components/Inputs/Input/types.ts
@@ -1,6 +1,7 @@
-import { ReactNode, CSSProperties } from 'react'
+import { ReactNode, CSSProperties, InputHTMLAttributes } from 'react'
 
-export interface InputProps {
+export interface InputProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
   type?: string
   disabled?: boolean
   value?: string

--- a/applications/launchpad/gui-react/src/components/Select/styles.tsx
+++ b/applications/launchpad/gui-react/src/components/Select/styles.tsx
@@ -102,4 +102,5 @@ export const Label = styled(Listbox.Label)<SelectInternalProps>`
   margin-bottom: ${({ theme }) => theme.spacingVertical()};
   color: ${({ theme, inverted }) =>
     inverted ? theme.inverted.primary : theme.primary};
+  font-family 'AvenirMedium';
 `

--- a/applications/launchpad/gui-react/src/containers/WalletContainer/PasswordBox.tsx
+++ b/applications/launchpad/gui-react/src/containers/WalletContainer/PasswordBox.tsx
@@ -41,6 +41,7 @@ const PasswordBox = ({
       <Text>{t.wallet.password.cta}</Text>
       <form onSubmit={formSubmitHandler}>
         <PasswordInput
+          autoFocus
           onChange={updatePassword}
           value={password}
           disabled={pending}

--- a/applications/launchpad/gui-react/src/containers/WalletContainer/TariWallet/TariId.tsx
+++ b/applications/launchpad/gui-react/src/containers/WalletContainer/TariWallet/TariId.tsx
@@ -32,12 +32,16 @@ const TariId = ({
         <SemiTransparent>({t.wallet.wallet.address})</SemiTransparent>
       </Text>
       <TariIdContainer>
-        <TariIdBox>{showEmoji ? emojiTariId.join(' | ') : tariId}</TariIdBox>
+        <TariIdBox>
+          <Text as='span'>{showEmoji ? emojiTariId.join(' | ') : tariId}</Text>
+        </TariIdBox>
         <div
           onClick={() => setShowEmoji(a => !a)}
           style={{
             cursor: 'pointer',
             textAlign: 'center',
+            position: 'relative',
+            top: '0.4em',
           }}
         >
           <Smiley


### PR DESCRIPTION
Description
---

- [x] fix label on Select component (didn't use Avenir)
![image](https://user-images.githubusercontent.com/9142942/168838110-07df9836-85fa-45bb-8a7f-1d2a0d149bb0.png)
- [x] fix tari wallet id box (not using Avenir)
![image](https://user-images.githubusercontent.com/9142942/168986197-8f5585b3-34c6-44b4-aae2-d179cc49eb56.png)
- [x] make password box on wallet autofocus
![wallet_password_autofocus](https://user-images.githubusercontent.com/9142942/168986932-af569e71-9d12-4dd8-8920-53f2a5b19cc0.gif)

Motivation and Context
---

#178

How Has This Been Tested?
---

