### PR TITLE
chore: yarn audit

### DIFF
--- a/applications/launchpad/gui-react/package.json
+++ b/applications/launchpad/gui-react/package.json
@@ -70,7 +70,9 @@
   "resolutions": {
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0",
-    "nth-check": "^2.0.1"
+    "nth-check": "^2.0.1",
+    "async": ">=2.6.4",
+    "minimist": ">=1.2.3"
   },
   "devDependencies": {
     "@redux-devtools/cli": "^1.0.7",

--- a/applications/launchpad/gui-react/yarn.lock
+++ b/applications/launchpad/gui-react/yarn.lock
@@ -3502,28 +3502,7 @@ async-retry@^1.2.1:
   dependencies:
     retry "0.13.1"
 
-async@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.0.0.tgz#d0900ad385af13804540a109c42166e3ae7b2b9d"
-  integrity sha512-x4YEotAaoO+dq8o23H0Clqm+b0KQ7hYHFfqxIz4ORzLzAdwH0K7S5/Q+mDo/wVyGdFYA0l7XE70Y9915PuEyqg==
-  dependencies:
-    lodash "^4.8.0"
-
-async@2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.3.0.tgz#1013d1051047dd320fe24e494d5c66ecaf6147d9"
-  integrity sha512-uDDBwBVKsWWe4uMmvVmFiW07K5BmdyZvSFzxlujNBtSJ/qzAlGM6UHOFZsQd5jsdmWatrCMWwYyVAc8cuJrepQ==
-  dependencies:
-    lodash "^4.14.0"
-
-async@^2.6.1, async@^2.6.2:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.4.tgz#706b7ff6084664cd7eae713f6f965433b5504221"
-  integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
-  dependencies:
-    lodash "^4.17.14"
-
-async@^3.1.0, async@^3.2.3:
+async@2.0.0, async@2.3.0, async@>=2.6.4, async@^2.6.1, async@^2.6.2, async@^3.1.0, async@^3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.3.tgz#ac53dafd3f4720ee9e8a160628f18ea91df196c9"
   integrity sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==
@@ -7927,7 +7906,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.7.0, lodash@^4.8.0:
+lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -8166,12 +8145,7 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
-
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.6:
+minimist@1.2.0, minimist@>=1.2.3, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==


### PR DESCRIPTION
Description
---

Fix yarn audit:

```
yarn audit v1.22.18
warning ../package.json: No license field
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ critical      │ Prototype Pollution in minimist                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimist                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.[6](https://github.com/Altalogy/tari/runs/6483922975?check_suite_focus=true#step:4:7)                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @redux-devtools/cli                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @redux-devtools/cli > socketcluster > minimist               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/106[7](https://github.com/Altalogy/tari/runs/6483922975?check_suite_focus=true#step:4:8)342                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ moderate      │ Prototype Pollution in minimist                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimist                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=1.2.3                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @redux-devtools/cli                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @redux-devtools/cli > socketcluster > minimist               │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1070254                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Prototype Pollution in async                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ async                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.6.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @redux-devtools/cli                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @redux-devtools/cli > socketcluster > async                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1070206                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ high          │ Prototype Pollution in async                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ async                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=2.6.4                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @redux-devtools/cli                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @redux-devtools/cli > socketcluster > sc-broker-cluster >    │
│               │ async                                                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1070206                     │
└───────────────┴──────────────────────────────────────────────────────────────┘
4 vulnerabilities found - Packages audited: 1707
Severity: 1 Moderate | 2 High | 1 Critical
Done in 1.6[9](https://github.com/Altalogy/tari/runs/6483922975?check_suite_focus=true#step:4:10)s.
```

Motivation and Context
---

Fix found vulnerabilities in:

[https://github.com/Altalogy/tari/actions/runs/2343555952](https://github.com/Altalogy/tari/actions/runs/2343555952)

How Has This Been Tested?
---

Running the `yarn audit`.

```
yarn audit v1.22.17
warning ../package.json: No license field
0 vulnerabilities found - Packages audited: 1729
✨  Done in 1.12s
```
