### PR TITLE
fix: review of mining boxes

### DIFF
--- a/applications/launchpad/gui-react/__tests__/mocks/states/miningStateTemplates.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/states/miningStateTemplates.ts
@@ -2,45 +2,32 @@ import { MiningState } from '../../../src/store/mining/types'
 
 export const initialMining: MiningState = {
   tari: {
-    sessions: [],
+    session: undefined,
   },
   merged: {
-    sessions: [],
+    session: undefined,
   },
 }
 
 export const miningWithSessions: MiningState = {
   tari: {
-    sessions: [
-      {
-        total: {
-          xtr: '1000',
-        },
+    session: {
+      startedAt: Number(Date.now()).toString(),
+      total: {
+        xtr: '1000',
       },
-      {
-        total: {
-          xtr: '2000',
-        },
-      },
-    ],
+    },
   },
   merged: {
     threads: 1,
     urls: ['firstAddress'],
     address: 'address',
-    sessions: [
-      {
-        total: {
-          xtr: '1000',
-          xmr: '1001',
-        },
+    session: {
+      startedAt: Number(Date.now()).toString(),
+      total: {
+        xtr: '1000',
+        xmr: '1001',
       },
-      {
-        total: {
-          xtr: '2000',
-          xmr: '2001',
-        },
-      },
-    ],
+    },
   },
 }

--- a/applications/launchpad/gui-react/src/components/NodeBox/NodeBox.test.tsx
+++ b/applications/launchpad/gui-react/src/components/NodeBox/NodeBox.test.tsx
@@ -11,7 +11,7 @@ describe('NodeBox', () => {
       <ThemeProvider theme={themes.light}>
         <NodeBox
           tag={{
-            text: 'Test text',
+            content: 'Test text',
             type: 'warning',
           }}
         />

--- a/applications/launchpad/gui-react/src/components/NodeBox/index.tsx
+++ b/applications/launchpad/gui-react/src/components/NodeBox/index.tsx
@@ -34,7 +34,7 @@ const NodeBox = ({
       <BoxHeader>
         {tag ? (
           <Tag type={tag.type} variant='large'>
-            {tag.text}
+            {tag.content}
           </Tag>
         ) : null}
       </BoxHeader>

--- a/applications/launchpad/gui-react/src/components/NodeBox/types.ts
+++ b/applications/launchpad/gui-react/src/components/NodeBox/types.ts
@@ -5,7 +5,7 @@ import { TagType } from '../Tag/types'
 export interface NodeBoxProps {
   title?: string
   tag?: {
-    text: string
+    text: string | ReactNode
     type?: TagType
   }
   style?: CSSWithSpring

--- a/applications/launchpad/gui-react/src/components/NodeBox/types.ts
+++ b/applications/launchpad/gui-react/src/components/NodeBox/types.ts
@@ -5,7 +5,7 @@ import { TagType } from '../Tag/types'
 export interface NodeBoxProps {
   title?: string
   tag?: {
-    text: string | ReactNode
+    content: string | ReactNode
     type?: TagType
   }
   style?: CSSWithSpring

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/MiningBox.test.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/MiningBox.test.tsx
@@ -10,7 +10,7 @@ import themes from '../../../styles/themes'
 import { Container } from '../../../store/containers/types'
 
 const emptyNodeState = {
-  sessions: [],
+  session: undefined,
 }
 
 const pausedContainersState = {

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
@@ -4,6 +4,7 @@ import deepmerge from 'deepmerge'
 import Button from '../../../components/Button'
 import CoinsList from '../../../components/CoinsList'
 import NodeBox, { NodeBoxContentPlaceholder } from '../../../components/NodeBox'
+import Text from '../../../components/Text'
 
 import { useAppDispatch } from '../../../store/hooks'
 
@@ -24,6 +25,7 @@ import RunningButton from '../../../components/RunningButton'
 
 const parseLastSessionToCoins = (
   lastSession: MiningSession | undefined,
+  theCurrentStatus: MiningBoxStatus,
   icons?: MiningCoinIconProp[],
 ) => {
   if (lastSession && lastSession.total) {
@@ -36,7 +38,7 @@ const parseLastSessionToCoins = (
         lastSession.total && lastSession.total[coin]
           ? lastSession.total[coin]
           : '0',
-      loading: !anyNonZeroCoin,
+      loading: !anyNonZeroCoin && theCurrentStatus === MiningBoxStatus.Running,
       suffixText: lastSession.finishedAt ? t.mining.minedInLastSession : '',
       icon: icons?.find(i => i.coin === coin)?.component,
     }))
@@ -91,6 +93,8 @@ const MiningBox = ({
 
   let theCurrentStatus = currentStatus
 
+  const lastSession = nodeState.session
+
   if (!theCurrentStatus) {
     if (
       containersState.error ||
@@ -99,16 +103,14 @@ const MiningBox = ({
       theCurrentStatus = MiningBoxStatus.Error
     } else if (containersState.running) {
       theCurrentStatus = MiningBoxStatus.Running
+    } else if (!lastSession) {
+      theCurrentStatus = MiningBoxStatus.PausedNoSession
     } else {
       theCurrentStatus = MiningBoxStatus.Paused
     }
   }
 
-  const lastSession = nodeState.sessions
-    ? nodeState.sessions[nodeState.sessions.length - 1]
-    : undefined
-
-  const coins = parseLastSessionToCoins(lastSession, icons)
+  const coins = parseLastSessionToCoins(lastSession, theCurrentStatus, icons)
 
   // Is there any outgoing action, so the buttons should be disabled?
   const disableActions = containersState.pending
@@ -150,6 +152,11 @@ const MiningBox = ({
         type: 'light',
       },
     },
+    [MiningBoxStatus.PausedNoSession]: {
+      tag: {
+        text: t.common.phrases.startHere,
+      },
+    },
     [MiningBoxStatus.Running]: {
       tag: {
         text: t.common.adjectives.running,
@@ -176,19 +183,20 @@ const MiningBox = ({
     },
   }
 
-  const currentState = useMemo(
-    () =>
-      deepmerge.all([
-        defaultConfig,
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        theCurrentStatus ? defaultStates[theCurrentStatus]! : {},
-        theCurrentStatus && statuses && statuses[theCurrentStatus]
-          ? // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            statuses[theCurrentStatus]!
-          : {},
-      ]) as NodeBoxStatusConfig,
-    [theCurrentStatus, nodeState],
-  )
+  const currentState = useMemo(() => {
+    const fromDefaultState = theCurrentStatus
+      ? defaultStates[theCurrentStatus]
+      : {}
+    const fromProps =
+      theCurrentStatus && statuses && statuses[theCurrentStatus]
+        ? statuses[theCurrentStatus]
+        : {}
+    return deepmerge.all([
+      defaultConfig,
+      fromDefaultState || {},
+      fromProps || {},
+    ]) as NodeBoxStatusConfig
+  }, [theCurrentStatus, nodeState, statuses])
 
   const componentForCurrentStatus = () => {
     if (children) {
@@ -220,6 +228,20 @@ const MiningBox = ({
               <div>{t.mining.placeholders.statusError}</div>
             </MiningBoxContent>
           </NodeBoxContentPlaceholder>
+        )
+      case MiningBoxStatus.PausedNoSession:
+        return (
+          <MiningBoxContent data-testid='mining-box-paused-content'>
+            <Text>{t.mining.readyToMiningText}</Text>
+            <Button
+              onClick={() => dispatch(actions.startMiningNode({ node: node }))}
+              disabled={disableActions}
+              loading={disableActions}
+              testId={`${node}-run-btn`}
+            >
+              {t.mining.actions.startMining}
+            </Button>
+          </MiningBoxContent>
         )
       case MiningBoxStatus.Paused:
         return (

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
@@ -139,23 +139,23 @@ const MiningBox = ({
   }> = {
     [MiningBoxStatus.SetupRequired]: {
       tag: {
-        text: t.common.phrases.startHere,
+        content: t.common.phrases.startHere,
       },
     },
     [MiningBoxStatus.Paused]: {
       tag: {
-        text: t.common.adjectives.paused,
+        content: t.common.adjectives.paused,
         type: 'light',
       },
     },
     [MiningBoxStatus.PausedNoSession]: {
       tag: {
-        text: t.common.phrases.startHere,
+        content: t.common.phrases.startHere,
       },
     },
     [MiningBoxStatus.Running]: {
       tag: {
-        text: t.common.adjectives.running,
+        content: t.common.adjectives.running,
         type: 'running',
       },
       boxStyle: {
@@ -173,7 +173,7 @@ const MiningBox = ({
     },
     [MiningBoxStatus.Error]: {
       tag: {
-        text: t.common.nouns.problem,
+        content: t.common.nouns.problem,
         type: 'warning',
       },
     },

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
@@ -141,10 +141,6 @@ const MiningBox = ({
       tag: {
         text: t.common.phrases.startHere,
       },
-      boxStyle: {
-        boxShadow: theme.shadow40,
-        borderColor: 'transparent',
-      },
     },
     [MiningBoxStatus.Paused]: {
       tag: {

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/types.ts
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/types.ts
@@ -19,7 +19,7 @@ export enum MiningBoxStatus {
 export interface NodeBoxStatusConfig {
   title?: string
   tag?: {
-    text: string | ReactNode
+    content: string | ReactNode
     type?: TagType
   }
   boxStyle?: CSSProperties

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/types.ts
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/types.ts
@@ -11,6 +11,7 @@ export enum MiningBoxStatus {
   Custom = 'custom',
   SetupRequired = 'setup_required',
   Paused = 'paused',
+  PausedNoSession = 'paused_no_session',
   Running = 'running',
   Error = 'error',
 }
@@ -18,7 +19,7 @@ export enum MiningBoxStatus {
 export interface NodeBoxStatusConfig {
   title?: string
   tag?: {
-    text: string
+    text: string | ReactNode
     type?: TagType
   }
   boxStyle?: CSSProperties

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/SetupMergedWithForm.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/SetupMergedWithForm.tsx
@@ -74,6 +74,7 @@ const SetupMergedWithForm = ({
                 <Input
                   placeholder={t.mining.setup.addressPlaceholder}
                   testId='address-input'
+                  autoFocus
                   {...field}
                 />
               )}

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/SetupMergedWithForm.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/SetupMergedWithForm.tsx
@@ -20,8 +20,10 @@ import { useTheme } from 'styled-components'
 
 const SetupMergedWithForm = ({
   mergedSetupRequired,
+  changeTag,
 }: {
   mergedSetupRequired: MergedMiningSetupRequired
+  changeTag: () => void
 }) => {
   const theme = useTheme()
   const dispatch = useAppDispatch()
@@ -47,7 +49,10 @@ const SetupMergedWithForm = ({
       {!revealForm ? (
         <Button
           variant='primary'
-          onClick={() => setRevealForm(true)}
+          onClick={() => {
+            setRevealForm(true)
+            changeTag()
+          }}
           disabled={
             mergedSetupRequired ===
             MergedMiningSetupRequired.MissingWalletAddress

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/index.tsx
@@ -77,12 +77,16 @@ const MiningBoxMerged = () => {
   const statuses = {
     [MiningBoxStatus.SetupRequired]: {
       tag: {
-        text: bestChoiceTag ? <BestChoiceTag /> : t.common.phrases.readyToSet,
+        content: bestChoiceTag ? (
+          <BestChoiceTag />
+        ) : (
+          t.common.phrases.readyToSet
+        ),
       },
     },
     [MiningBoxStatus.PausedNoSession]: {
       tag: {
-        text: t.common.phrases.readyToGo,
+        content: t.common.phrases.readyToGo,
       },
     },
     [MiningBoxStatus.Running]: {

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/index.tsx
@@ -12,11 +12,30 @@ import MiningBox from '../MiningBox'
 import { MiningBoxStatus } from '../MiningBox/types'
 
 import { Container } from '../../../store/containers/types'
+
+import t from '../../../locales'
+
 // import SetupMerged from './SetupMerged'
 import SetupMergedWithForm from './SetupMergedWithForm'
+import {
+  BestChoiceTagIcon,
+  BestChoiceTagText,
+  StyledBestChoiceTag,
+} from './styles'
+
+const BestChoiceTag = () => {
+  return (
+    <StyledBestChoiceTag>
+      <BestChoiceTagText>{t.common.phrases.bestChoice} </BestChoiceTagText>
+      <BestChoiceTagIcon>💪</BestChoiceTagIcon>
+    </StyledBestChoiceTag>
+  )
+}
 
 const MiningBoxMerged = () => {
   const theme = useTheme()
+
+  const [bestChoiceTag, setBestChoiceTag] = useState(false)
 
   let boxContent: ReactNode | undefined
   let currentStatus: MiningBoxStatus | undefined
@@ -56,6 +75,16 @@ const MiningBoxMerged = () => {
   }, [containersState])
 
   const statuses = {
+    [MiningBoxStatus.SetupRequired]: {
+      tag: {
+        text: bestChoiceTag ? <BestChoiceTag /> : t.common.phrases.readyToSet,
+      },
+    },
+    [MiningBoxStatus.PausedNoSession]: {
+      tag: {
+        text: t.common.phrases.readyToGo,
+      },
+    },
     [MiningBoxStatus.Running]: {
       boxStyle: {
         background: theme.mergedGradient,
@@ -73,7 +102,10 @@ const MiningBoxMerged = () => {
      */
     // boxContent = <SetupMerged mergedSetupRequired={mergedSetupRequired} />
     boxContent = (
-      <SetupMergedWithForm mergedSetupRequired={mergedSetupRequired} />
+      <SetupMergedWithForm
+        mergedSetupRequired={mergedSetupRequired}
+        changeTag={() => setBestChoiceTag(true)}
+      />
     )
   }
 

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/index.tsx
@@ -113,8 +113,8 @@ const MiningBoxMerged = () => {
     <MiningBox
       node='merged'
       icons={[
-        { coin: 'xtr', component: <SvgMoneroSignet key='monero-icon' /> },
-        { coin: 'xmr', component: <SvgTariSignet key='tari-icon' /> },
+        { coin: 'xmr', component: <SvgMoneroSignet key='monero-icon' /> },
+        { coin: 'xtr', component: <SvgTariSignet key='tari-icon' /> },
       ]}
       testId='merged-mining-box'
       statuses={statuses}

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/styles.ts
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/styles.ts
@@ -17,3 +17,21 @@ export const FormTextWrapper = styled.div`
   padding-bottom: ${({ theme }) => theme.spacingVertical()};
   margin-bottom: ${({ theme }) => theme.spacingVertical()};
 `
+
+export const StyledBestChoiceTag = styled.span`
+  display: flex;
+  align-items: center;
+  flex: 1;
+`
+
+export const BestChoiceTagText = styled.span`
+  display: inline-flex;
+`
+
+export const BestChoiceTagIcon = styled.span`
+  font-size: 0.84em;
+  line-height: 0.4em;
+  position: relative;
+  display: inline-flex;
+  marginleft: 4px;
+`

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxTari/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxTari/index.tsx
@@ -17,8 +17,11 @@ import {
 } from '../../../store/mining/selectors'
 import { TariMiningSetupRequired } from '../../../store/mining/types'
 import { Container } from '../../../store/containers/types'
+import { useTheme } from 'styled-components'
 
 const MiningBoxTari = () => {
+  const theme = useTheme()
+
   const nodeState = useAppSelector(selectTariMiningState)
   const containersState = useAppSelector(selectTariContainers)
   const tariSetupRequired = useAppSelector(selectTariSetupRequired)
@@ -50,6 +53,15 @@ const MiningBoxTari = () => {
     }
   }, [containersState])
 
+  const statuses = {
+    [MiningBoxStatus.SetupRequired]: {
+      boxStyle: {
+        boxShadow: theme.shadow40,
+        borderColor: 'transparent',
+      },
+    },
+  }
+
   let boxContent: ReactNode | undefined
   let currentStatus: MiningBoxStatus | undefined
 
@@ -65,6 +77,7 @@ const MiningBoxTari = () => {
       node='tari'
       icons={[{ coin: 'xtr', component: <SvgTariSignet key='tari-icon' /> }]}
       testId='tari-mining-box'
+      statuses={statuses}
       currentStatus={currentStatus}
       nodeState={nodeState}
       containersState={containersState}

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningHeaderTip/MiningHeaderTip.test.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningHeaderTip/MiningHeaderTip.test.tsx
@@ -39,6 +39,26 @@ describe('MiningHeaderTip', () => {
     expect(el).toBeInTheDocument()
   })
 
+  it('should render "one click away" when mining node status is PAUSED and tokens were not mined yet', () => {
+    render(
+      <Provider
+        store={configureStore({
+          reducer: rootReducer,
+          preloadedState: {
+            wallet: unlockedWallet,
+            mining: initialMining,
+          },
+        })}
+      >
+        <ThemeProvider theme={themes.light}>
+          <MiningHeaderTip />
+        </ThemeProvider>
+      </Provider>,
+    )
+    const el = screen.getByText(t.mining.headerTips.oneClickAway)
+    expect(el).toBeInTheDocument()
+  })
+
   it('should render "continue mining" when mining node status is PAUSED and tokens were already mined', () => {
     render(
       <Provider

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningHeaderTip/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningHeaderTip/index.tsx
@@ -13,6 +13,7 @@ import { tbotactions } from '../../../store/tbot'
 import {
   selectTariContainers,
   selectTariMiningState,
+  selectTariSetupRequired,
 } from '../../../store/mining/selectors'
 
 import MessagesConfig from '../../../config/helpMessagesConfig'
@@ -25,6 +26,7 @@ import { useAppSelector } from '../../../store/hooks'
 const MiningHeaderTip = () => {
   const dispatch = useAppDispatch()
 
+  const tariSetupRequired = useAppSelector(selectTariSetupRequired)
   const tariMiningState = useAppSelector(selectTariMiningState)
   const tariContainers = useAppSelector(selectTariContainers)
 
@@ -32,7 +34,11 @@ const MiningHeaderTip = () => {
 
   if (tariContainers.running) {
     text = t.mining.headerTips.runningOn
-  } else if (tariMiningState.sessions && tariMiningState.sessions.length > 0) {
+  } else if (tariSetupRequired) {
+    text = t.mining.headerTips.oneStepAway
+  } else if (!tariMiningState.session) {
+    text = t.mining.headerTips.oneClickAway
+  } else if (tariMiningState.session && tariMiningState.session.startedAt) {
     text = t.mining.headerTips.continueMining
   }
 

--- a/applications/launchpad/gui-react/src/containers/WalletPasswordWizard/WalletPasswordForm/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/WalletPasswordWizard/WalletPasswordForm/index.tsx
@@ -52,6 +52,8 @@ const WalletPasswordForm = ({
           render={({ field }) => (
             <PasswordInput
               placeholder={t.walletPasswordWizard.passwordPlaceholder}
+              type='password'
+              autoFocus
               testId='password-input'
               useStrengthMeter
               {...field}

--- a/applications/launchpad/gui-react/src/containers/WalletPasswordWizard/WalletPasswordForm/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/WalletPasswordWizard/WalletPasswordForm/index.tsx
@@ -52,7 +52,6 @@ const WalletPasswordForm = ({
           render={({ field }) => (
             <PasswordInput
               placeholder={t.walletPasswordWizard.passwordPlaceholder}
-              type='password'
               autoFocus
               testId='password-input'
               useStrengthMeter

--- a/applications/launchpad/gui-react/src/locales/common.ts
+++ b/applications/launchpad/gui-react/src/locales/common.ts
@@ -54,7 +54,10 @@ const translations: { [key: string]: { [key: string]: string } } = {
   },
   phrases: {
     actionRequired: 'Action required',
+    bestChoice: 'Best choice',
     startHere: 'Start here',
+    readyToGo: 'Ready to go',
+    readyToSet: 'Ready to set',
   },
   containers: {
     [Container.Tor]: 'Tor',

--- a/applications/launchpad/gui-react/src/locales/mining.ts
+++ b/applications/launchpad/gui-react/src/locales/mining.ts
@@ -1,8 +1,10 @@
 const translations = {
   minedInLastSession: 'mined in last session',
   setUpTariWalletSubmitBtn: 'Set up Tari Wallet & start mining',
+  readyToMiningText: 'Everyting is set. You’re ready to go!',
   headerTips: {
     oneStepAway: 'You are one step away from starting mining.',
+    oneClickAway: 'You are one click away from starting mining.',
     continueMining:
       'Keep on going. You are one click away from starting mining.',
     runningOn: 'Awesome! Tari Mining is on.',

--- a/applications/launchpad/gui-react/src/locales/mining.ts
+++ b/applications/launchpad/gui-react/src/locales/mining.ts
@@ -1,7 +1,7 @@
 const translations = {
   minedInLastSession: 'mined in last session',
   setUpTariWalletSubmitBtn: 'Set up Tari Wallet & start mining',
-  readyToMiningText: 'Everyting is set. You’re ready to go!',
+  readyToMiningText: 'Everything is set. You’re ready to go!',
   headerTips: {
     oneStepAway: 'You are one step away from starting mining.',
     oneClickAway: 'You are one click away from starting mining.',

--- a/applications/launchpad/gui-react/src/store/mining/index.ts
+++ b/applications/launchpad/gui-react/src/store/mining/index.ts
@@ -6,7 +6,7 @@ import { MiningState } from './types'
 
 const currencies: Record<'tari' | 'merged', string[]> = {
   tari: ['xtr'],
-  merged: ['xtr', 'xmr'],
+  merged: ['xmr', 'xtr'],
 }
 
 export const initialState: MiningState = {

--- a/applications/launchpad/gui-react/src/store/mining/index.ts
+++ b/applications/launchpad/gui-react/src/store/mining/index.ts
@@ -6,7 +6,7 @@ import { MiningState } from './types'
 
 const currencies: Record<'tari' | 'merged', string[]> = {
   tari: ['xtr'],
-  merged: ['xmr', 'xtr'],
+  merged: ['xtr', 'xmr'],
 }
 
 export const initialState: MiningState = {

--- a/applications/launchpad/gui-react/src/store/mining/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/mining/thunks.ts
@@ -78,12 +78,12 @@ export const stopMiningNode = createAsyncThunk<
     sessionId?: string
   },
   { state: RootState }
->('mining/stopNode', async ({ containers, node, sessionId }, thunkApi) => {
+>('mining/stopNode', async ({ containers, node }, thunkApi) => {
   try {
     const promises = containers.map(async c => {
       await thunkApi.dispatch(containersActions.stop(c.id)).unwrap()
     })
-    thunkApi.dispatch(miningActions.stopSession({ node, sessionId }))
+    thunkApi.dispatch(miningActions.stopSession({ node }))
     await Promise.all(promises)
   } catch (e) {
     return thunkApi.rejectWithValue(e)

--- a/applications/launchpad/gui-react/src/store/mining/types.ts
+++ b/applications/launchpad/gui-react/src/store/mining/types.ts
@@ -25,17 +25,10 @@ export interface MiningSession {
   finishedAt?: string
   id?: string // uuid (?)
   total?: Record<string, string> // i,e { xtr: 1000 bignumber (?) }
-  pending?: boolean
-  history?: {
-    timestamp?: string // UTC timestamp
-    amount?: string // bignumber (?)
-    chain?: string // ie. xtr, xmr aka coin/currency?
-    type?: string // to enum, ie. mined, earned, received, sent
-  }[]
 }
 
 export interface MiningNodeState {
-  sessions?: MiningSession[]
+  session?: MiningSession
 }
 
 export interface MergedMiningNodeState extends MiningNodeState {

--- a/applications/launchpad/gui-react/src/useMiningSimulator.ts
+++ b/applications/launchpad/gui-react/src/useMiningSimulator.ts
@@ -12,8 +12,8 @@ const useMiningSimulator = () => {
 
   useEffect(() => {
     const timer = setInterval(async () => {
-      const sessions = store.getState().mining.tari.sessions
-      if (!sessions || sessions[sessions.length - 1].finishedAt) {
+      const session = store.getState().mining.tari.session
+      if (!session || session.finishedAt) {
         return
       }
       dispatch(miningActions.addAmount({ amount: '1000.1232', node: 'tari' }))
@@ -23,8 +23,8 @@ const useMiningSimulator = () => {
 
   useEffect(() => {
     const timer = setInterval(async () => {
-      const sessions = store.getState().mining.merged.sessions
-      if (!sessions || sessions[sessions.length - 1].finishedAt) {
+      const session = store.getState().mining.merged.session
+      if (!session || session.finishedAt) {
         return
       }
       dispatch(miningActions.addAmount({ amount: '50', node: 'merged' }))


### PR DESCRIPTION
Description
---

Adding few missing pieces to the Mining. It is a follow up to the #192 (split into two PRs so it's easier to review)

- [x] changed the session structure in Redux from array to the single object (I suppose that we won't keep the history of sessions there)
- [x] added missing semi-state in mining boxes (paused but with no sessions)
- [x] fixed showing loader to zero values in `paused` state
- [x] added autofocus to inputs in mining boxes
- [x] fixed: MiningBox by default doesn't drop any shadow. The shadow should be added only for Tari Mining box when user has to set up wallet.
- [x] added missing tags in Merged mining (`Ready to set` etc.)
- [x] fixed wrong icons assignment in merged mining box
- [x] added missing case for Header tips above mining boxes

Motivation and Context
---

Fixing issues found after another review of the Mining

How Has This Been Tested?
---


https://user-images.githubusercontent.com/11715931/169586828-72469195-eecf-4926-9017-bf756d3fb003.mp4


https://user-images.githubusercontent.com/11715931/169587253-1e4d4e82-25f7-4bb6-bcd8-d54e0ea70b1f.mp4



