### PR TITLE
fix: refactor stopping mining nodes

### DIFF
--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/MiningBox.test.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/MiningBox.test.tsx
@@ -36,7 +36,6 @@ describe('MiningBox', () => {
             node='tari'
             nodeState={emptyNodeState}
             containersState={pausedContainersState}
-            containersToStopOnPause={[]}
           >
             <p>{testText}</p>
           </MiningBox>
@@ -75,7 +74,6 @@ describe('MiningBox', () => {
             node='tari'
             nodeState={emptyNodeState}
             containersState={containersState}
-            containersToStopOnPause={[]}
           />
         </ThemeProvider>
       </Provider>,
@@ -97,7 +95,6 @@ describe('MiningBox', () => {
             node='tari'
             nodeState={emptyNodeState}
             containersState={pausedContainersState}
-            containersToStopOnPause={[]}
           />
         </ThemeProvider>
       </Provider>,
@@ -124,7 +121,6 @@ describe('MiningBox', () => {
             node='tari'
             nodeState={emptyNodeState}
             containersState={containersState}
-            containersToStopOnPause={[]}
           />
         </ThemeProvider>
       </Provider>,

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
@@ -74,7 +74,6 @@ const parseLastSessionToCoins = (
  * @param {string} [testId] - custom test id
  * @param {MiningNodeState} [nodeState] - the node state from Redux's mining
  * @param {MiningContainersState} [containersState] - the containers from Redux's mining
- * @param {{ id: string; type: Container }[]} [containersToStopOnPause] - list of containers that need to be stopped when user clicks on pause button.
  * @param {ReactNode} [children] - component overriding the generic one composed by this container for a given status.
  */
 const MiningBox = ({
@@ -86,7 +85,6 @@ const MiningBox = ({
   testId = 'mining-box-cmp',
   nodeState,
   containersState,
-  containersToStopOnPause,
 }: MiningBoxProps) => {
   const dispatch = useAppDispatch()
   const theme = useTheme()
@@ -268,8 +266,6 @@ const MiningBox = ({
                 dispatch(
                   actions.stopMiningNode({
                     node,
-                    containers: containersToStopOnPause,
-                    sessionId: lastSession?.id,
                   }),
                 )
               }

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/types.ts
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/types.ts
@@ -1,6 +1,5 @@
 import { CSSProperties, ReactNode } from 'react'
 import { TagType } from '../../../components/Tag/types'
-import { Container } from '../../../store/containers/types'
 import {
   MiningContainersState,
   MiningNodeState,
@@ -46,5 +45,4 @@ export interface MiningBoxProps {
   testId?: string
   nodeState: MiningNodeState
   containersState: MiningContainersState
-  containersToStopOnPause: { id: string; type: Container }[]
 }

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode, useState } from 'react'
 import { useTheme } from 'styled-components'
 import { useAppSelector } from '../../../store/hooks'
 import {
@@ -10,8 +10,6 @@ import SvgMoneroSignet from '../../../styles/Icons/MoneroSignet'
 import SvgTariSignet from '../../../styles/Icons/TariSignet'
 import MiningBox from '../MiningBox'
 import { MiningBoxStatus } from '../MiningBox/types'
-
-import { Container } from '../../../store/containers/types'
 
 import t from '../../../locales'
 
@@ -43,36 +41,6 @@ const MiningBoxMerged = () => {
   const nodeState = useAppSelector(selectMergedMiningState)
   const containersState = useAppSelector(selectMergedContainers)
   const mergedSetupRequired = useAppSelector(selectMergedSetupRequired)
-
-  // Stop only Merged related containers on pause/stop action
-  const [containersToStopOnPause, setContainersToStopOnPause] = useState<
-    { id: string; type: Container }[]
-  >([])
-
-  useEffect(() => {
-    if (
-      (!containersState ||
-        !containersState.dependsOn ||
-        containersState.dependsOn.length === 0) &&
-      containersToStopOnPause.length > 0
-    ) {
-      setContainersToStopOnPause([])
-    } else if (containersState && containersState.dependsOn?.length > 0) {
-      const cs = containersState.dependsOn.filter(
-        c =>
-          [Container.XMrig, Container.MMProxy, Container.Monerod].includes(
-            c.type,
-          ) && c.id,
-      )
-
-      setContainersToStopOnPause(
-        cs.map(c => ({
-          id: c.id,
-          type: c.type,
-        })),
-      )
-    }
-  }, [containersState])
 
   const statuses = {
     [MiningBoxStatus.SetupRequired]: {
@@ -125,7 +93,6 @@ const MiningBoxMerged = () => {
       currentStatus={currentStatus}
       nodeState={nodeState}
       containersState={containersState}
-      containersToStopOnPause={containersToStopOnPause}
     >
       {boxContent}
     </MiningBox>

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxTari/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxTari/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useState } from 'react'
+import { ReactNode } from 'react'
 
 import MiningBox from '../MiningBox'
 import { MiningBoxStatus } from '../MiningBox/types'
@@ -16,7 +16,6 @@ import {
   selectTariSetupRequired,
 } from '../../../store/mining/selectors'
 import { TariMiningSetupRequired } from '../../../store/mining/types'
-import { Container } from '../../../store/containers/types'
 import { useTheme } from 'styled-components'
 
 const MiningBoxTari = () => {
@@ -25,33 +24,6 @@ const MiningBoxTari = () => {
   const nodeState = useAppSelector(selectTariMiningState)
   const containersState = useAppSelector(selectTariContainers)
   const tariSetupRequired = useAppSelector(selectTariSetupRequired)
-
-  // Stop only SHA3 miner on pause/stop action
-  const [containersToStopOnPause, setContainersToStopOnPause] = useState<
-    { id: string; type: Container }[]
-  >([])
-
-  useEffect(() => {
-    if (
-      (!containersState ||
-        !containersState.dependsOn ||
-        containersState.dependsOn.length === 0) &&
-      containersToStopOnPause.length > 0
-    ) {
-      setContainersToStopOnPause([])
-    } else if (containersState && containersState.dependsOn?.length > 0) {
-      const cs = containersState.dependsOn.filter(
-        c => [Container.SHA3Miner].includes(c.type) && c.id,
-      )
-
-      setContainersToStopOnPause(
-        cs.map(c => ({
-          id: c.id,
-          type: c.type,
-        })),
-      )
-    }
-  }, [containersState])
 
   const statuses = {
     [MiningBoxStatus.SetupRequired]: {
@@ -81,7 +53,6 @@ const MiningBoxTari = () => {
       currentStatus={currentStatus}
       nodeState={nodeState}
       containersState={containersState}
-      containersToStopOnPause={containersToStopOnPause}
     >
       {boxContent}
     </MiningBox>

--- a/applications/launchpad/gui-react/src/store/containers/index.ts
+++ b/applications/launchpad/gui-react/src/store/containers/index.ts
@@ -8,7 +8,7 @@ import {
   Container,
   SystemEventAction,
 } from './types'
-import { start, stop } from './thunks'
+import { start, stop, stopByType } from './thunks'
 
 const getInitialServiceStatus = (
   lastAction: SystemEventAction,
@@ -129,6 +129,6 @@ const servicesSlice = createSlice({
 })
 
 const { actions: syncActions } = servicesSlice
-export const actions = { start, stop, ...syncActions }
+export const actions = { start, stop, stopByType, ...syncActions }
 
 export default servicesSlice.reducer

--- a/applications/launchpad/gui-react/src/store/containers/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/containers/selectors.ts
@@ -17,7 +17,7 @@ export const selectState = (rootState: RootState) => rootState.containers
 export const selectPendingContainers = (rootState: RootState) =>
   rootState.containers.pending
 
-const selectContainerByType = (c: Container) => (r: RootState) => {
+export const selectContainerByType = (c: Container) => (r: RootState) => {
   const containers = Object.entries(r.containers.containers).filter(
     ([, value]) => value.type === c,
   )

--- a/applications/launchpad/gui-react/src/store/containers/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/containers/thunks.ts
@@ -12,6 +12,7 @@ import {
   Container,
   ServiceDescriptor,
 } from './types'
+import { selectContainerByType } from './selectors'
 
 export const start = createAsyncThunk<
   { id: ContainerId; unsubscribeStats: UnlistenFn },
@@ -62,3 +63,20 @@ export const stop = createAsyncThunk<void, ContainerId, { state: RootState }>(
     }
   },
 )
+
+export const stopByType = createAsyncThunk<
+  void,
+  Container,
+  { state: RootState }
+>('containers/stop', async (containerType, thunkApi) => {
+  try {
+    const rootState = thunkApi.getState()
+    const container = selectContainerByType(containerType)(rootState)
+
+    if (container && container.containerId) {
+      await thunkApi.dispatch(stop(container.containerId))
+    }
+  } catch (error) {
+    return thunkApi.rejectWithValue(error)
+  }
+})

--- a/applications/launchpad/gui-react/src/store/containers/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/containers/thunks.ts
@@ -68,7 +68,7 @@ export const stopByType = createAsyncThunk<
   void,
   Container,
   { state: RootState }
->('containers/stop', async (containerType, thunkApi) => {
+>('containers/stopByType', async (containerType, thunkApi) => {
   try {
     const rootState = thunkApi.getState()
     const container = selectContainerByType(containerType)(rootState)

--- a/applications/launchpad/gui-react/src/store/mining/index.ts
+++ b/applications/launchpad/gui-react/src/store/mining/index.ts
@@ -1,10 +1,11 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { v4 as uuidv4 } from 'uuid'
+import { MiningNodeType } from '../../types/general'
 
 import { startMiningNode, stopMiningNode } from './thunks'
 import { MiningState } from './types'
 
-const currencies: Record<'tari' | 'merged', string[]> = {
+const currencies: Record<MiningNodeType, string[]> = {
   tari: ['xtr'],
   merged: ['xtr', 'xmr'],
 }
@@ -31,7 +32,7 @@ const miningSlice = createSlice({
      */
     addAmount(
       state,
-      action: PayloadAction<{ amount: string; node: 'tari' | 'merged' }>,
+      action: PayloadAction<{ amount: string; node: MiningNodeType }>,
     ) {
       const node = action.payload.node
 
@@ -42,7 +43,7 @@ const miningSlice = createSlice({
         ).toString()
       }
     },
-    startNewSession(state, action: PayloadAction<{ node: 'tari' | 'merged' }>) {
+    startNewSession(state, action: PayloadAction<{ node: MiningNodeType }>) {
       const { node } = action.payload
       const total: Record<string, string> = {}
       currencies[node].forEach(c => {
@@ -55,7 +56,7 @@ const miningSlice = createSlice({
         total,
       }
     },
-    stopSession(state, action: PayloadAction<{ node: 'tari' | 'merged' }>) {
+    stopSession(state, action: PayloadAction<{ node: MiningNodeType }>) {
       const { node } = action.payload
 
       const session = state[node].session

--- a/applications/launchpad/gui-react/src/store/mining/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/mining/thunks.ts
@@ -66,24 +66,42 @@ export const startMiningNode = createAsyncThunk<
 })
 
 /**
- * Stop nodes with given IDs
- * @prop {{ id: string; type: Container }[]} containers - the list of nodes with id and type
+ * Stop containers of a given mining node (ie. tari, merged).
+ * It doesn't stop common containers, like Tor, Wallet, and BaseNode.
+ * @prop {{ node: MiningNodeType }} node - the mining node, ie. 'tari'
  * @returns {Promise<void>}
  */
 export const stopMiningNode = createAsyncThunk<
   void,
   {
-    node: 'tari' | 'merged'
-    containers: { id: string; type: Container }[]
-    sessionId?: string
+    node: MiningNodeType
   },
   { state: RootState }
->('mining/stopNode', async ({ containers, node }, thunkApi) => {
+>('mining/stopNode', async ({ node }, thunkApi) => {
   try {
-    const promises = containers.map(async c => {
-      await thunkApi.dispatch(containersActions.stop(c.id)).unwrap()
-    })
+    const promises = []
+
+    switch (node) {
+      case 'tari':
+        promises.push(
+          thunkApi.dispatch(containersActions.stopByType(Container.SHA3Miner)),
+        )
+        break
+      case 'merged':
+        promises.push(
+          thunkApi.dispatch(containersActions.stopByType(Container.MMProxy)),
+        )
+        promises.push(
+          thunkApi.dispatch(containersActions.stopByType(Container.XMrig)),
+        )
+        promises.push(
+          thunkApi.dispatch(containersActions.stopByType(Container.Monerod)),
+        )
+        break
+    }
+
     thunkApi.dispatch(miningActions.stopSession({ node }))
+
     await Promise.all(promises)
   } catch (e) {
     return thunkApi.rejectWithValue(e)


### PR DESCRIPTION
Description
---

This PR makes that MiningBox component does not have to be aware of containers ids to stop them. Instead, the component dispatches the thunk that will find containers by itself.

Motivation and Context
---

Follow up to the #170 

How Has This Been Tested?
---

`yarn test` and live app usage.
