### PR TITLE
feat: containers stats separated from containers statuses

### DIFF
--- a/applications/launchpad/gui-react/__tests__/mocks/states/containersStateTemplates.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/states/containersStateTemplates.ts
@@ -1,6 +1,7 @@
 import {
   Container,
   ContainerId,
+  ContainerStats,
   ContainerStatus,
   ServicesState,
   SystemEventAction,
@@ -19,6 +20,7 @@ const noErrors = {
 
 const runningContainers = (cs: Container[]) => {
   const containers: Record<ContainerId, ContainerStatus> = {}
+  const stats: Record<ContainerId, ContainerStats> = {}
 
   cs.forEach(c => {
     containers[`${c.toLowerCase()}-id`] = {
@@ -26,12 +28,13 @@ const runningContainers = (cs: Container[]) => {
       error: undefined,
       status: SystemEventAction.Start,
       timestamp: Number(Date.now()),
-      stats: {
-        cpu: 0,
-        memory: 0,
-        unsubscribe: () => {
-          return
-        },
+    }
+
+    stats[`${c.toLowerCase()}-id`] = {
+      cpu: 0,
+      memory: 0,
+      unsubscribe: () => {
+        return
       },
     }
   })
@@ -39,10 +42,27 @@ const runningContainers = (cs: Container[]) => {
   return containers
 }
 
+const zeroedStatsForContainers = (cs: Container[]) => {
+  const stats: Record<ContainerId, ContainerStats> = {}
+
+  cs.forEach(c => {
+    stats[`${c.toLowerCase()}-id`] = {
+      cpu: 0,
+      memory: 0,
+      unsubscribe: () => {
+        return
+      },
+    }
+  })
+
+  return stats
+}
+
 export const allStopped: ServicesState = {
   errors: noErrors,
   pending: [],
   containers: {},
+  stats: {},
 }
 
 export const tariContainersRunning: ServicesState = {
@@ -50,6 +70,14 @@ export const tariContainersRunning: ServicesState = {
   pending: [],
   containers: {
     ...runningContainers([
+      Container.Tor,
+      Container.BaseNode,
+      Container.Wallet,
+      Container.SHA3Miner,
+    ]),
+  },
+  stats: {
+    ...zeroedStatsForContainers([
       Container.Tor,
       Container.BaseNode,
       Container.Wallet,

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo } from 'react'
 
 import { useAppSelector, useAppDispatch } from '../../../../store/hooks'
-import { selectContainersStatuses } from '../../../../store/containers/selectors'
+import { selectContainersStatusesWithStats } from '../../../../store/containers/selectors'
 import { Container, ContainerId } from '../../../../store/containers/types'
 import { actions } from '../../../../store/containers'
 import Alert from '../../../../components/Alert'
@@ -12,7 +12,7 @@ const ContainersContainer = () => {
   const [error, setError] = useState('')
 
   const dispatch = useAppDispatch()
-  const containerStatuses = useAppSelector(selectContainersStatuses)
+  const containerStatuses = useAppSelector(selectContainersStatusesWithStats)
   const containers = useMemo(
     () =>
       containerStatuses.map(({ container, status }) => ({

--- a/applications/launchpad/gui-react/src/store/containers/index.test.ts
+++ b/applications/launchpad/gui-react/src/store/containers/index.test.ts
@@ -10,11 +10,13 @@ describe('updateStatus action', () => {
       containers: {
         someContainerId: {
           status: SystemEventAction.Create,
-          stats: {
-            cpu: 2,
-            memory: 1,
-            unsubscribe,
-          },
+        },
+      },
+      stats: {
+        someContainerId: {
+          cpu: 2,
+          memory: 1,
+          unsubscribe,
         },
       },
     } as unknown as ServicesState
@@ -23,11 +25,13 @@ describe('updateStatus action', () => {
       containers: {
         someContainerId: {
           status: SystemEventAction.Start,
-          stats: {
-            cpu: 2,
-            memory: 1,
-            unsubscribe,
-          },
+        },
+      },
+      stats: {
+        someContainerId: {
+          cpu: 2,
+          memory: 1,
+          unsubscribe,
         },
       },
     }
@@ -50,6 +54,7 @@ describe('updateStatus action', () => {
     const state = {
       pending: [],
       containers: {},
+      stats: {},
     } as unknown as ServicesState
 
     // when
@@ -65,10 +70,6 @@ describe('updateStatus action', () => {
     const newContainer = nextState.containers.newContainerId
     expect(newContainer).toMatchObject({
       status: SystemEventAction.Create,
-      stats: {
-        cpu: 0,
-        memory: 0,
-      },
     })
   })
 
@@ -102,11 +103,13 @@ describe('updateStatus action', () => {
         someContainerId: {
           timestamp: 123123,
           status: SystemEventAction.Create,
-          stats: {
-            cpu: 2,
-            memory: 1,
-            unsubscribe,
-          },
+        },
+      },
+      stats: {
+        someContainerId: {
+          cpu: 2,
+          memory: 1,
+          unsubscribe,
         },
       },
     } as unknown as ServicesState
@@ -137,11 +140,13 @@ describe('updateStatus action', () => {
           containers: {
             someContainerId: {
               status: SystemEventAction.Create,
-              stats: {
-                cpu: 2,
-                memory: 1,
-                unsubscribe,
-              },
+            },
+          },
+          stats: {
+            someContainerId: {
+              cpu: 2,
+              memory: 1,
+              unsubscribe,
             },
           },
         } as unknown as ServicesState
@@ -166,11 +171,13 @@ describe('updateStatus action', () => {
           containers: {
             someContainerId: {
               status: SystemEventAction.Create,
-              stats: {
-                cpu: 2,
-                memory: 1,
-                unsubscribe: jest.fn(),
-              },
+            },
+          },
+          stats: {
+            someContainerId: {
+              cpu: 2,
+              memory: 1,
+              unsubscribe: jest.fn(),
             },
           },
         } as unknown as ServicesState
@@ -186,8 +193,8 @@ describe('updateStatus action', () => {
 
         // then
         expect(nextState.containers.someContainerId).toBeDefined()
-        expect(nextState.containers.someContainerId.stats.cpu).toBe(0)
-        expect(nextState.containers.someContainerId.stats.memory).toBe(0)
+        expect(nextState.stats.someContainerId.cpu).toBe(0)
+        expect(nextState.stats.someContainerId.memory).toBe(0)
       })
     })
   })

--- a/applications/launchpad/gui-react/src/store/containers/selectors.test.ts
+++ b/applications/launchpad/gui-react/src/store/containers/selectors.test.ts
@@ -18,11 +18,6 @@ describe('containers/selectors', () => {
       type: Container.Tor,
       running: false,
       pending: false,
-      stats: {
-        cpu: 0,
-        memory: 0,
-        unsubscribe: () => undefined,
-      },
     }
 
     // when
@@ -46,11 +41,6 @@ describe('containers/selectors', () => {
       type: Container.Tor,
       running: false,
       pending: true,
-      stats: {
-        cpu: 0,
-        memory: 0,
-        unsubscribe: () => undefined,
-      },
     }
 
     // when
@@ -62,7 +52,6 @@ describe('containers/selectors', () => {
 
   it('should return container by type', () => {
     // given
-    const unsubscribe = jest.fn()
     const rootState = {
       containers: {
         errors: {},
@@ -71,11 +60,6 @@ describe('containers/selectors', () => {
           containerId: {
             type: Container.Tor,
             status: SystemEventAction.Start,
-            stats: {
-              cpu: 7,
-              memory: 7,
-              unsubscribe,
-            },
           },
         },
       },
@@ -87,11 +71,6 @@ describe('containers/selectors', () => {
       error: undefined,
       running: true,
       pending: false,
-      stats: {
-        cpu: 7,
-        memory: 7,
-        unsubscribe,
-      },
     }
 
     // when
@@ -118,10 +97,6 @@ describe('containers/selectors', () => {
             type: Container.Tor,
             error: containerError,
             status: SystemEventAction.Start,
-            stats: {
-              cpu: 7,
-              memory: 7,
-            },
           },
         },
       },
@@ -149,10 +124,6 @@ describe('containers/selectors', () => {
           containerId: {
             type: Container.Tor,
             status: SystemEventAction.Start,
-            stats: {
-              cpu: 7,
-              memory: 7,
-            },
           },
         },
       },
@@ -176,7 +147,6 @@ describe('containers/selectors', () => {
   runningIndicationTestcases.forEach(([status, expected]) =>
     it(`should return running=${expected} for status "${status}"`, () => {
       // given
-      const unsubscribe = jest.fn()
       const rootState = {
         containers: {
           errors: {},
@@ -185,11 +155,6 @@ describe('containers/selectors', () => {
             containerId: {
               type: Container.Tor,
               status: status,
-              stats: {
-                cpu: 7,
-                memory: 7,
-                unsubscribe,
-              },
             },
           },
         },
@@ -207,7 +172,6 @@ describe('containers/selectors', () => {
 
   it('should return container with biggest timestamp value if multiple containers of the same type are present', () => {
     // given
-    const unsubscribe = jest.fn()
     const rootState = {
       containers: {
         errors: {},
@@ -217,21 +181,11 @@ describe('containers/selectors', () => {
             timestamp: 0,
             type: Container.Tor,
             status: SystemEventAction.Start,
-            stats: {
-              cpu: 7,
-              memory: 7,
-              unsubscribe,
-            },
           },
           anotherContainerId: {
             timestamp: 1,
             type: Container.Tor,
             status: SystemEventAction.Start,
-            stats: {
-              cpu: 8,
-              memory: 8,
-              unsubscribe,
-            },
           },
         },
       },
@@ -244,11 +198,6 @@ describe('containers/selectors', () => {
       error: undefined,
       running: true,
       pending: false,
-      stats: {
-        cpu: 8,
-        memory: 8,
-        unsubscribe,
-      },
     }
 
     // when
@@ -262,7 +211,6 @@ describe('containers/selectors', () => {
 
   it('should return container other than Start or Destroy as pending', () => {
     // given
-    const unsubscribe = jest.fn()
     const rootState = {
       containers: {
         errors: {},
@@ -271,11 +219,6 @@ describe('containers/selectors', () => {
           containerId: {
             type: Container.Tor,
             status: SystemEventAction.Create,
-            stats: {
-              cpu: 7,
-              memory: 7,
-              unsubscribe,
-            },
           },
         },
       },
@@ -287,11 +230,6 @@ describe('containers/selectors', () => {
       error: undefined,
       running: false,
       pending: true,
-      stats: {
-        cpu: 7,
-        memory: 7,
-        unsubscribe,
-      },
     }
 
     // when

--- a/applications/launchpad/gui-react/src/store/containers/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/containers/selectors.ts
@@ -1,16 +1,11 @@
-import { createSelector } from '@reduxjs/toolkit'
 import { RootState } from '../'
 
-import { ContainerStatusDto, Container, SystemEventAction } from './types'
-
-const noContainerData = (type: Container, error?: string) => ({
-  id: undefined,
-  type,
-  status: undefined,
-  pending: false,
-  running: false,
-  error: error,
-})
+import {
+  ContainerStatusDto,
+  Container,
+  SystemEventAction,
+  ContainerStatusDtoWithStats,
+} from './types'
 
 export const selectState = (rootState: RootState) => rootState.containers
 
@@ -27,13 +22,8 @@ const selectContainerByType = (c: Container) => (r: RootState) => {
   return { containerId, containerStatus }
 }
 
-const selectContainerError = (c: Container) => (r: RootState) => {
-  if (r.containers.errors && r.containers.errors[c]) {
-    return r.containers.errors[c]
-  }
-
-  return
-}
+export const selectContainerStats = (containerId: string) => (r: RootState) =>
+  r.containers.stats[containerId]
 
 type ContainerStatusSelector = (
   c: Container,
@@ -56,11 +46,6 @@ export const selectContainerStatus: ContainerStatusSelector =
         error: typeError,
         running: false,
         pending,
-        stats: {
-          cpu: 0,
-          memory: 0,
-          unsubscribe: () => undefined,
-        },
       }
     }
 
@@ -74,6 +59,32 @@ export const selectContainerStatus: ContainerStatusSelector =
       running: containerStatus.status === SystemEventAction.Start,
       type: containerType,
       error: containerStatus.error || typeError,
+    }
+  }
+
+type ContainerStatusSelectorWithStats = (
+  c: Container,
+) => (r: RootState) => ContainerStatusDtoWithStats
+export const selectContainerStatusWithStats: ContainerStatusSelectorWithStats =
+  containerType => rootState => {
+    const container = selectContainerStatus(containerType)(rootState)
+
+    if (!container.id) {
+      return {
+        ...container,
+        stats: {
+          cpu: 0,
+          memory: 0,
+          unsubscribe: () => undefined,
+        },
+      }
+    }
+
+    const containerStats = selectContainerStats(container.id)(rootState)
+
+    return {
+      ...container,
+      stats: containerStats,
     }
   }
 
@@ -91,29 +102,8 @@ export const selectContainersStatuses = (rootState: RootState) =>
     status: selectContainerStatus(type as Container)(rootState),
   }))
 
-export const selectContainerWithMemo = (c: Container) =>
-  createSelector(
-    (s: RootState) => selectContainerByType(c)(s),
-    selectPendingContainers,
-    (s: RootState) => selectContainerError(c)(s),
-    (container, pendingState, errorState) => {
-      if (!container.containerId || !container.containerStatus) {
-        return noContainerData(c, errorState)
-      }
-
-      const pending =
-        pendingState.includes(c) || pendingState.includes(container.containerId)
-
-      return {
-        id: container.containerId,
-        type: c,
-        status: container.containerStatus.status,
-        pending:
-          pending ||
-          (container.containerStatus.status !== SystemEventAction.Start &&
-            container.containerStatus.status !== SystemEventAction.Destroy),
-        running: container.containerStatus.status === SystemEventAction.Start,
-        error: container.containerStatus.error || errorState,
-      }
-    },
-  )
+export const selectContainersStatusesWithStats = (rootState: RootState) =>
+  Object.values(Container).map(type => ({
+    container: type,
+    status: selectContainerStatusWithStats(type as Container)(rootState),
+  }))

--- a/applications/launchpad/gui-react/src/store/containers/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/containers/thunks.ts
@@ -52,8 +52,9 @@ export const stop = createAsyncThunk<void, ContainerId, { state: RootState }>(
     try {
       const rootState = thunkApi.getState()
       const containerStatus = rootState.containers.containers[containerId]
+      const containerStats = rootState.containers.stats[containerId]
 
-      containerStatus.stats.unsubscribe()
+      containerStats.unsubscribe()
       await invoke('stop_service', {
         serviceName: (containerStatus.type || '').toString(),
       })

--- a/applications/launchpad/gui-react/src/store/containers/types.ts
+++ b/applications/launchpad/gui-react/src/store/containers/types.ts
@@ -27,16 +27,17 @@ export type ServiceDescriptor = {
   name: string
 }
 
+export type ContainerStats = {
+  cpu: number
+  memory: number
+  unsubscribe: UnlistenFn
+}
+
 export type ContainerStatus = {
   status: SystemEventAction
   timestamp: number
   type?: Container
   error?: any
-  stats: {
-    cpu: number
-    memory: number
-    unsubscribe: UnlistenFn
-  }
 }
 
 export type ContainerStatusDto = {
@@ -45,11 +46,10 @@ export type ContainerStatusDto = {
   running: boolean
   pending: boolean
   error?: any
-  stats: {
-    cpu: number
-    memory: number
-    unsubscribe: UnlistenFn
-  }
+}
+
+export type ContainerStatusDtoWithStats = ContainerStatusDto & {
+  stats: ContainerStats
 }
 
 export type ContainerStateFields = Pick<
@@ -64,6 +64,7 @@ export type ServicesState = {
   errors: Record<Container, any>
   pending: Array<Container | ContainerId>
   containers: Record<ContainerId, ContainerStatus>
+  stats: Record<ContainerId, ContainerStats>
 }
 
 export interface StatsEventPayload {

--- a/applications/launchpad/gui-react/src/store/mining/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/mining/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit'
 import { RootState } from '..'
-import { selectContainerWithMemo } from '../containers/selectors'
+import { selectContainerStatusWithStats } from '../containers/selectors'
 import { Container } from '../containers/types'
 import { selectWalletSetupRequired } from '../wallet/selectors'
 import {
@@ -15,10 +15,10 @@ import {
 export const selectTariMiningState = (r: RootState) => r.mining.tari
 
 export const selectTariContainers = createSelector(
-  selectContainerWithMemo(Container.Tor),
-  selectContainerWithMemo(Container.BaseNode),
-  selectContainerWithMemo(Container.Wallet),
-  selectContainerWithMemo(Container.SHA3Miner),
+  selectContainerStatusWithStats(Container.Tor),
+  selectContainerStatusWithStats(Container.BaseNode),
+  selectContainerStatusWithStats(Container.Wallet),
+  selectContainerStatusWithStats(Container.SHA3Miner),
   (tor, baseNode, wallet, sha3) => {
     const containers = [tor, baseNode, wallet, sha3]
     const errors = containers
@@ -35,11 +35,6 @@ export const selectTariContainers = createSelector(
       error: errors.length > 0 ? errors : undefined,
       dependsOn: [tor, baseNode, wallet, sha3],
     } as MiningContainersState
-  },
-  {
-    memoizeOptions: {
-      equalityCheck: (a, b) => JSON.stringify(a) === JSON.stringify(b),
-    },
   },
 )
 
@@ -59,11 +54,11 @@ export const selectMergedMiningAddress = (r: RootState) =>
   r.mining.merged.address
 
 export const selectMergedContainers = createSelector(
-  selectContainerWithMemo(Container.Tor),
-  selectContainerWithMemo(Container.BaseNode),
-  selectContainerWithMemo(Container.Wallet),
-  selectContainerWithMemo(Container.MMProxy),
-  selectContainerWithMemo(Container.XMrig),
+  selectContainerStatusWithStats(Container.Tor),
+  selectContainerStatusWithStats(Container.BaseNode),
+  selectContainerStatusWithStats(Container.Wallet),
+  selectContainerStatusWithStats(Container.MMProxy),
+  selectContainerStatusWithStats(Container.XMrig),
   (tor, baseNode, wallet, mmproxy, xmrig) => {
     const containers = [tor, baseNode, wallet, mmproxy, xmrig]
     const errors = containers
@@ -80,11 +75,6 @@ export const selectMergedContainers = createSelector(
       error: errors.length > 0 ? errors : undefined,
       dependsOn: [tor, baseNode, wallet, xmrig, mmproxy],
     } as MiningContainersState
-  },
-  {
-    memoizeOptions: {
-      equalityCheck: (a, b) => JSON.stringify(a) === JSON.stringify(b),
-    },
   },
 )
 


### PR DESCRIPTION
Description
---

Move `stats` from the `containers.containers` to the `containers.stats`.

Motivation and Context
---

#193 



How Has This Been Tested?
---

`yarn test`

https://user-images.githubusercontent.com/11715931/169860343-da4d90fc-e85a-46be-b018-38bbc8595b93.mp4

