### PR TITLE
chore: launchpad build in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,7 @@ jobs:
           yarn install
           yarn lint
           cd ..
+          yarn install
           yarn tauri build
       - name: test key manager wasm
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - ci-*
   pull_request:
     branches-ignore:
-      - 'launchpad_such_wow' # TODO: Remove this filter once the branch is merged into development
+      - "launchpad_such_wow" # TODO: Remove this filter once the branch is merged into development
     types:
       - opened
       - reopened
@@ -77,6 +77,10 @@ jobs:
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v1
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
       - name: ubuntu dependencies
         run: |
           sudo apt-get update && \
@@ -92,6 +96,14 @@ jobs:
           librsvg2-dev \
           libprotobuf-dev \
           protobuf-compiler
+      - name: build launchpad
+        with:
+          command: |
+            cd applications/launchpad/gui-react
+            yarn install
+            yarn lint
+            cd ..
+            yarn tauri build
       - name: cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -189,6 +201,10 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: ${{ env.toolchain }}
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
       - uses: Swatinem/rust-cache@v1
       - name: ubuntu dependencies
         run: |
@@ -205,6 +221,14 @@ jobs:
           librsvg2-dev \
           libprotobuf-dev \
           protobuf-compiler
+      - name: build launchpad
+        with:
+          command: |
+            cd applications/launchpad/gui-react
+            yarn install
+            yarn lint
+            cd ..
+            yarn tauri build
       - name: test key manager wasm
         run: |
           npm install -g wasm-pack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,10 @@ jobs:
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v1
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
       - name: ubuntu dependencies
         run: |
           sudo apt-get update && \
@@ -143,6 +147,15 @@ jobs:
           librsvg2-dev \
           libprotobuf-dev \
           protobuf-compiler
+
+      - name: build launchpad
+        run: |
+          cd applications/launchpad/gui-react
+          yarn install
+          yarn lint
+          cd ..
+          yarn install
+          yarn tauri build
       - name: rustup show
         run: |
           rustup show
@@ -162,11 +175,17 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: build launchpad
+      - name: setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+      - name: build gui-react
         run: |
-          cd applications/launchpad
-          npm ci
-          npm run build
+          cd applications/launchpad/gui-react
+          yarn install
+          yarn lint:ci
+          yarn test:ci
+          yarn build
       - name: build collectibles web-app
         run: |
           cd applications/tari_collectibles/web-app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - ci-*
   pull_request:
     branches-ignore:
-      - "launchpad_such_wow" # TODO: Remove this filter once the branch is merged into development
+      - "launchpad_such_wow-temp" # TODO: Remove this filter once the branch is merged into development
     types:
       - opened
       - reopened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,14 +96,12 @@ jobs:
           librsvg2-dev \
           libprotobuf-dev \
           protobuf-compiler
-      - name: build launchpad
+      - name: build gui-react
         run: |
           cd applications/launchpad/gui-react
           yarn install
           yarn lint
-          cd ..
-          yarn install
-          yarn tauri build
+          yarn build
       - name: cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -148,14 +146,12 @@ jobs:
           libprotobuf-dev \
           protobuf-compiler
 
-      - name: build launchpad
+      - name: build gui-react
         run: |
           cd applications/launchpad/gui-react
           yarn install
           yarn lint
-          cd ..
-          yarn install
-          yarn tauri build
+          yarn build
       - name: rustup show
         run: |
           rustup show
@@ -240,14 +236,12 @@ jobs:
           librsvg2-dev \
           libprotobuf-dev \
           protobuf-compiler
-      - name: build launchpad
+      - name: build gui-react
         run: |
           cd applications/launchpad/gui-react
           yarn install
           yarn lint
-          cd ..
-          yarn install
-          yarn tauri build
+          yarn build
       - name: test key manager wasm
         run: |
           npm install -g wasm-pack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,13 +97,12 @@ jobs:
           libprotobuf-dev \
           protobuf-compiler
       - name: build launchpad
-        with:
-          command: |
-            cd applications/launchpad/gui-react
-            yarn install
-            yarn lint
-            cd ..
-            yarn tauri build
+        run: |
+          cd applications/launchpad/gui-react
+          yarn install
+          yarn lint
+          cd ..
+          yarn tauri build
       - name: cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -222,13 +221,12 @@ jobs:
           libprotobuf-dev \
           protobuf-compiler
       - name: build launchpad
-        with:
-          command: |
-            cd applications/launchpad/gui-react
-            yarn install
-            yarn lint
-            cd ..
-            yarn tauri build
+        run: |
+          cd applications/launchpad/gui-react
+          yarn install
+          yarn lint
+          cd ..
+          yarn tauri build
       - name: test key manager wasm
         run: |
           npm install -g wasm-pack

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
           yarn install
           yarn lint
           cd ..
+          yarn install
           yarn tauri build
       - name: cargo check
         uses: actions-rs/cargo@v1
@@ -161,9 +162,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v2
-      - name: build launchpad_v2
+      - name: build launchpad
         run: |
-          cd applications/launchpad_v2
+          cd applications/launchpad
           npm ci
           npm run build
       - name: build collectibles web-app

--- a/applications/launchpad/gui-react/.eslintrc.js
+++ b/applications/launchpad/gui-react/.eslintrc.js
@@ -21,12 +21,20 @@ module.exports = {
   plugins: ['react', '@typescript-eslint', 'prettier'],
   rules: {
     'prettier/prettier': 'error',
-    indent: ['warn', 2, { SwitchCase: 1 }],
+    indent: ['off', 2, { SwitchCase: 1 }],
     'linebreak-style': ['error', 'unix'],
     'no-console': 1,
     quotes: ['error', 'single'],
     'react/react-in-jsx-scope': 'off',
     semi: ['error', 'never'],
     'object-curly-spacing': ['error', 'always', { objectsInObjects: true }],
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
   },
 }

--- a/applications/launchpad/gui-react/__tests__/mocks/mockImages.js
+++ b/applications/launchpad/gui-react/__tests__/mocks/mockImages.js
@@ -1,1 +1,4 @@
+// Copyright 2022 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
 module.exports = {}

--- a/applications/launchpad/gui-react/__tests__/mocks/mockStyles.js
+++ b/applications/launchpad/gui-react/__tests__/mocks/mockStyles.js
@@ -1,1 +1,4 @@
+// Copyright 2022 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
 module.exports = {}

--- a/applications/launchpad/gui-react/__tests__/mocks/mockTauriIPC.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/mockTauriIPC.ts
@@ -1,3 +1,6 @@
+// Copyright 2022 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
 import { mockIPC } from '@tauri-apps/api/mocks'
 
 /**

--- a/applications/launchpad/gui-react/src/components/TBot/index.tsx
+++ b/applications/launchpad/gui-react/src/components/TBot/index.tsx
@@ -1,4 +1,4 @@
-import { useSpring, config } from 'react-spring'
+import { useSpring } from 'react-spring'
 import SvgTBotBase from '../../styles/Icons/TBotBase'
 import SvgTBotHearts from '../../styles/Icons/TBotHearts'
 import SvgTBotHeartsMonero from '../../styles/Icons/TBotHeartsMonero'

--- a/applications/launchpad/gui-react/src/components/Tabs/styles.ts
+++ b/applications/launchpad/gui-react/src/components/Tabs/styles.ts
@@ -1,3 +1,4 @@
+/* eslint-disable indent */
 import { TabProp } from './types'
 import { animated } from 'react-spring'
 import styled from 'styled-components'

--- a/applications/launchpad/gui-react/src/containers/Dashboard/DashboardContainer/components/DashboardTabs/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/DashboardContainer/components/DashboardTabs/index.tsx
@@ -18,7 +18,6 @@ import t from '../../../../../locales'
  * Helper composing all dashboard tabs.
  */
 const composeNodeTabs = ({
-  miningNodeState,
   baseNodeState,
   walletState,
 }: {

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
@@ -30,6 +30,7 @@ const ContainersContainer = () => {
   const start = async (container: Container) => {
     try {
       await dispatch(actions.start(container)).unwrap()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       setError(e.toString())
     }
@@ -37,6 +38,7 @@ const ContainersContainer = () => {
   const stop = async (containerId: ContainerId) => {
     try {
       await dispatch(actions.stop(containerId)).unwrap()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       setError(e.toString())
     }

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/types.ts
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/types.ts
@@ -4,6 +4,7 @@ type ContainerDto = {
   id: ContainerId
   container: Container
   cpu: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error?: any
   memory: number
   pending: boolean

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm.tsx
@@ -2,7 +2,6 @@ import { Schedule } from '../../../types/general'
 
 const ScheduleForm = ({
   value,
-  onChange,
 }: {
   value: Schedule
   onChange: (s: Schedule) => void

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/index.tsx
@@ -14,10 +14,6 @@ import { setTheme } from '../../store/app'
 import { selectTheme } from '../../store/app/selectors'
 
 import { actions } from '../../store/wallet'
-import Button from '../../components/Button'
-import SvgArrowLeft1 from '../../styles/Icons/ArrowLeft1'
-import SvgWallet from '../../styles/Icons/Wallet'
-import SvgSetting from '../../styles/Icons/Setting'
 
 import { NodesContainer } from './styles'
 import MiningBoxTari from './MiningBoxTari'

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
@@ -19,7 +19,7 @@ import { SettingsProps, SettingsComponentProps } from './types'
 
 const renderSettings = (
   settings: Settings,
-  props: SettingsProps,
+  _props: SettingsProps,
 ): ReactNode => {
   if (settings === Settings.Wallet) {
     return <WalletSettings />

--- a/applications/launchpad/gui-react/src/store/app/index.ts
+++ b/applications/launchpad/gui-react/src/store/app/index.ts
@@ -73,10 +73,10 @@ const appSlice = createSlice({
       delete state.schedules[scheduleId]
     },
     updateSchedule(
-      state,
-      { payload }: { payload: { scheduleId: string; value: Schedule } },
+      _state,
+      _payload: { payload: { scheduleId: string; value: Schedule } },
     ) {
-      console.log('update schedule', payload)
+      // console.log('update schedule', payload)
     },
   },
 })

--- a/applications/launchpad/gui-react/src/store/containers/types.ts
+++ b/applications/launchpad/gui-react/src/store/containers/types.ts
@@ -31,6 +31,7 @@ export type ContainerStatus = {
   status: SystemEventAction
   timestamp: number
   type?: Container
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error?: any
   stats: {
     cpu: number
@@ -44,6 +45,7 @@ export type ContainerStatusDto = {
   type: Container
   running: boolean
   pending: boolean
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error?: any
   stats: {
     cpu: number
@@ -53,6 +55,7 @@ export type ContainerStatusDto = {
 }
 
 export type ServicesState = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   errors: Record<Container, any>
   pending: Array<Container | ContainerId>
   containers: Record<ContainerId, ContainerStatus>

--- a/applications/launchpad/gui-react/src/store/mining/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/mining/thunks.ts
@@ -8,8 +8,7 @@ import { MiningNodeType } from '../../types/general'
  */
 export const startMiningNode = createAsyncThunk<void, { node: MiningNodeType }>(
   'mining/startNode',
-  async ({ node }) => {
-    console.log(`starting ${node} node`)
+  async () => {
     return await new Promise(resolve => setTimeout(resolve, 2000))
   },
 )
@@ -21,8 +20,7 @@ export const startMiningNode = createAsyncThunk<void, { node: MiningNodeType }>(
  */
 export const stopMiningNode = createAsyncThunk<void, { node: MiningNodeType }>(
   'mining/stopNode',
-  async ({ node }) => {
-    console.log(`stopping ${node} node`)
+  async () => {
     return await new Promise(resolve => setTimeout(resolve, 2000))
   },
 )

--- a/applications/launchpad/gui-react/src/store/settings/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/settings/thunks.ts
@@ -1,5 +1,5 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
-import { cacheDir, sep } from '@tauri-apps/api/path'
+import { cacheDir } from '@tauri-apps/api/path'
 
 const getSettings = async () => ({
   walletPassword: 'tari',

--- a/applications/launchpad/gui-react/src/store/settings/types.ts
+++ b/applications/launchpad/gui-react/src/store/settings/types.ts
@@ -10,5 +10,6 @@ export enum Settings {
 export type SettingsState = {
   open: boolean
   which: Settings
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   serviceSettings: any
 }

--- a/applications/launchpad/gui-react/src/store/wallet/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/wallet/thunks.ts
@@ -9,7 +9,7 @@ export const unlockWallet = createAsyncThunk<
     tari: { balance: number; available: number }
   },
   WalletPassword
->('wallet/unlock', async password => {
+>('wallet/unlock', async _password => {
   await new Promise(resolve => setTimeout(resolve, 2000))
 
   return {

--- a/applications/launchpad/gui-react/src/useSystemEvents.ts
+++ b/applications/launchpad/gui-react/src/useSystemEvents.ts
@@ -18,9 +18,10 @@ export const useSystemEvents = ({ dispatch }: { dispatch: AppDispatch }) => {
     let unsubscribe
 
     const listenToSystemEvents = async () => {
-      const systemEvents = new Map<string, number>()
+      // const systemEvents = new Map<string, number>()
       const unlisten = await listen(
         'tari://docker-system-event',
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (event: any) => {
           if (event.payload.Type === SystemEventType.Container) {
             const containerId = event.payload.Actor.ID
@@ -30,8 +31,8 @@ export const useSystemEvents = ({ dispatch }: { dispatch: AppDispatch }) => {
               return
             }
 
-            console.log(`ACTION ${action} - ${containerId} - ${image}`)
-            console.log(event)
+            // console.log(`ACTION ${action} - ${containerId} - ${image}`)
+            // console.log(event)
 
             dispatch(actions.updateStatus({ containerId, action }))
 
@@ -41,7 +42,7 @@ export const useSystemEvents = ({ dispatch }: { dispatch: AppDispatch }) => {
       )
 
       unsubscribe = () => {
-        console.log(JSON.stringify(systemEvents, null, 2))
+        // console.log(JSON.stringify(systemEvents, null, 2))
         unlisten()
       }
     }

--- a/scripts/file_license_check.sh
+++ b/scripts/file_license_check.sh
@@ -2,7 +2,7 @@
 # run from the repo root
 
 rg -i "Copyright.*The Tari Project" --files-without-match \
-    -g '!*.{Dockerfile,asc,bat,config,config.js,css,csv,drawio,gitkeep,hbs,html,iss,json,lock,md,min.js,ps1,py,rc,scss,sh,sql,svg,toml,txt,yml,vue}' . \
+    -g '!*.{Dockerfile,asc,bat,config,config.js,css,csv,drawio,gitkeep,hbs,html,iss,json,lock,md,min.js,ps1,py,rc,scss,sh,sql,svg,toml,txt,yml,vue,ts,tsx}' . \
     | sort >/tmp/rgtemp
 
 DIFFS=$(diff -u .license.ignore /tmp/rgtemp)


### PR DESCRIPTION
Description
---

Fix failing Ci jobs by:
- [x] adding `gui-react/build`
- [x] fixing lint warnings (lint warnings in CI env are treated as errors and they are failing the job)
- [x] ignore `.ts` and `.tsx` files to pass *files licenses* check

List of changes in jobs:

- `clippy` - added nothing, failing but issue is resolved on the upstream repo
- `check nightly` - added `gui-react`'s lint and build (only `gui-react`,  not whole launchpad)
- `build` - added `gui-react`'s lint and build (only `gui-react`,  not whole launchpad)
- `build stable` - added `gui-react`'s lint and build (only `gui-react`,  not whole launchpad)
- `javascript` - added `gui-react`'s lint, test and build (only `gui-react`,  not whole launchpad)
- `test` - added `gui-react`'s lint, test and build (only `gui-react`,  not whole launchpad)

Motivation and Context
---

#180 

How Has This Been Tested?
---

<img width="885" alt="image" src="https://user-images.githubusercontent.com/11715931/170225584-e949e1b8-c146-4db5-abd4-39fcdcbc66bf.png">
