### PR TITLE
fix: locale format of mining values

### DIFF
--- a/applications/launchpad/gui-react/src/components/CoinsList/index.tsx
+++ b/applications/launchpad/gui-react/src/components/CoinsList/index.tsx
@@ -9,7 +9,7 @@ const formatAmount = (amount: string) => {
     return '00,000'
   } else {
     try {
-      return Number(amount).toLocaleString()
+      return Number(amount).toLocaleString([], { maximumFractionDigits: 2 })
     } catch (err) {
       return '-'
     }

--- a/applications/launchpad/gui-react/src/components/CoinsList/index.tsx
+++ b/applications/launchpad/gui-react/src/components/CoinsList/index.tsx
@@ -6,12 +6,13 @@ import { CoinsListProps } from './types'
 
 const formatAmount = (amount: string) => {
   if (Number(amount) === 0) {
-    return '00 000'
+    return '00,000'
   } else {
-    // Add spaces to number
-    const splitted = amount.toString().split('.')
-    splitted[0] = splitted[0].replace(/\B(?=(\d{3})+(?!\d))/g, ' ')
-    return splitted.join('.')
+    try {
+      return Number(amount).toLocaleString()
+    } catch (err) {
+      return '-'
+    }
   }
 }
 


### PR DESCRIPTION
Description
---

Switch to `toLocaleString` in formatting the mining values.

Motivation and Context
---

#198 

How Has This Been Tested?
---

<img width="450" alt="image" src="https://user-images.githubusercontent.com/11715931/170021903-82854e61-e1c5-4b6c-9b36-f1c11933682f.png">

