### PR TITLE
feat: scheduling fixes and manual overrides

### DIFF
--- a/applications/launchpad/gui-react/src/components/Checkbox/index.tsx
+++ b/applications/launchpad/gui-react/src/components/Checkbox/index.tsx
@@ -14,6 +14,7 @@ import { Wrapper, CheckWrapper } from './styles'
  * @prop {(v: boolean) => void} onChange - when state changes, this callback is called with new value
  * @prop {string} children - label shown next to the tick box
  * @prop {CSSProperties} [style] - allows to extend main wrapper element styles
+ * @prop {boolean} disabled - indicates whether to render in disabled UI state
  *
  * @example
  * <Checkbox
@@ -28,19 +29,29 @@ const Checkbox = ({
   onChange,
   children,
   style,
+  disabled,
 }: {
   checked: boolean
   onChange: (v: boolean) => void
   children: string
   style?: CSSProperties
+  disabled?: boolean
 }) => {
   const theme = useTheme()
 
-  const color = checked ? theme.primary : theme.secondary
+  const color = disabled
+    ? theme.placeholderText
+    : checked
+    ? theme.primary
+    : theme.secondary
 
   return (
-    <Wrapper style={style} onClick={() => onChange(!checked)}>
-      <CheckWrapper checked={checked}>
+    <Wrapper
+      disabled={disabled}
+      style={style}
+      onClick={() => onChange(!checked)}
+    >
+      <CheckWrapper checked={checked} disabled={disabled}>
         {checked && (
           <TickIcon color={theme.accent} width='0.9em' height='0.9em' />
         )}

--- a/applications/launchpad/gui-react/src/components/Checkbox/styles.ts
+++ b/applications/launchpad/gui-react/src/components/Checkbox/styles.ts
@@ -1,19 +1,27 @@
 import styled from 'styled-components'
 
-export const Wrapper = styled.div`
+export const Wrapper = styled.div<{ disabled?: boolean }>`
   display: flex;
-  alignyitems: baseline;
+  pointer-events: ${({ disabled }) => (disabled ? 'none' : 'auto')};
 `
 
-export const CheckWrapper = styled.div<{ checked: boolean }>`
+export const CheckWrapper = styled.div<{
+  checked: boolean
+  disabled?: boolean
+}>`
   display: flex;
   justify-content: center;
   align-items: center;
   width: 1em;
   height: 1em;
   border: 2px solid
-    ${({ checked, theme }) => (checked ? theme.accent : theme.secondary)};
+    ${({ disabled, checked, theme }) => {
+      if (disabled) {
+        return theme.placeholderText
+      }
+      return checked ? theme.accent : theme.secondary
+    }};
   border-radius: 3px;
   margin-right: ${({ theme }) => theme.spacing(0.5)};
-  cursor: pointer;
+  cursor: ${({ disabled }) => (disabled ? 'default' : 'pointer')};
 `

--- a/applications/launchpad/gui-react/src/components/DatePicker/DatePicker.tsx
+++ b/applications/launchpad/gui-react/src/components/DatePicker/DatePicker.tsx
@@ -7,7 +7,7 @@ import ArrowRight from '../../styles/Icons/ArrowRight2'
 import t from '../../locales'
 import { month } from '../../utils/Format'
 import {
-  clearTime,
+  startOfDay,
   endOfMonth,
   startOfMonth,
   isCurrentMonth,
@@ -36,7 +36,7 @@ const DatePickerComponent = ({
   style,
 }: Omit<DatePickerProps, 'open'>) => {
   const theme = useTheme()
-  const valueWithoutTime = value && clearTime(value)
+  const valueWithoutTime = value && startOfDay(value)
 
   const {
     calendar,
@@ -94,8 +94,8 @@ const DatePickerComponent = ({
           {week.map(day => {
             const isInMonth = inRange(
               day,
-              startOfMonth(clearTime(viewing)),
-              endOfMonth(clearTime(viewing)),
+              startOfMonth(viewing),
+              endOfMonth(viewing),
             )
             const labelColor = isInMonth
               ? isSelected(day)
@@ -103,7 +103,16 @@ const DatePickerComponent = ({
                 : undefined
               : theme.placeholderText
             const disabled =
-              !allowPast && clearTime(day) < clearTime(new Date())
+              !allowPast && startOfDay(day) < startOfDay(new Date())
+            console.log(
+              day,
+              startOfDay(day) < startOfDay(new Date()),
+              isSelected(day),
+              {
+                day: startOfDay(day),
+                date: startOfDay(new Date()),
+              },
+            )
 
             return (
               <Day

--- a/applications/launchpad/gui-react/src/components/DatePicker/DatePicker.tsx
+++ b/applications/launchpad/gui-react/src/components/DatePicker/DatePicker.tsx
@@ -104,15 +104,6 @@ const DatePickerComponent = ({
               : theme.placeholderText
             const disabled =
               !allowPast && startOfDay(day) < startOfDay(new Date())
-            console.log(
-              day,
-              startOfDay(day) < startOfDay(new Date()),
-              isSelected(day),
-              {
-                day: startOfDay(day),
-                date: startOfDay(new Date()),
-              },
-            )
 
             return (
               <Day

--- a/applications/launchpad/gui-react/src/components/TBot/HelpComponents/MergedMining/MergedMining.test.tsx
+++ b/applications/launchpad/gui-react/src/components/TBot/HelpComponents/MergedMining/MergedMining.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { ThemeProvider } from 'styled-components'
-import themes from '../../../../styles/themes'
 import { Provider } from 'react-redux'
+
+import themes from '../../../../styles/themes'
 import { store } from '../../../../store'
 
 import { Message1, Message2 } from '.'
@@ -13,7 +14,6 @@ describe('MergedMiningMessages', () => {
         <ThemeProvider theme={themes.light}>
           <Message1 />
         </ThemeProvider>
-        ,
       </Provider>,
     )
 
@@ -27,7 +27,6 @@ describe('MergedMiningMessages', () => {
         <ThemeProvider theme={themes.light}>
           <Message2 />
         </ThemeProvider>
-        ,
       </Provider>,
     )
 

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { useTheme } from 'styled-components'
 import deepmerge from 'deepmerge'
 
@@ -9,7 +10,7 @@ import Text from '../../../components/Text'
 import { useAppDispatch } from '../../../store/hooks'
 
 import { actions } from '../../../store/mining'
-import { MiningSession } from '../../../store/mining/types'
+import { MiningActionReason, MiningSession } from '../../../store/mining/types'
 
 import t from '../../../locales'
 
@@ -20,7 +21,6 @@ import {
   NodeBoxStatusConfig,
 } from './types'
 import { MiningBoxContent, NodeIcons } from './styles'
-import { useMemo } from 'react'
 import RunningButton from '../../../components/RunningButton'
 import { tbotactions } from '../../../store/tbot'
 
@@ -215,7 +215,12 @@ const MiningBox = ({
               {coins ? <CoinsList coins={coins} /> : null}
               <Button
                 onClick={() =>
-                  dispatch(actions.startMiningNode({ node: node }))
+                  dispatch(
+                    actions.startMiningNode({
+                      node,
+                      reason: MiningActionReason.Manual,
+                    }),
+                  )
                 }
                 disabled={disableActions}
                 loading={disableActions}
@@ -232,7 +237,14 @@ const MiningBox = ({
           <MiningBoxContent data-testid='mining-box-paused-content'>
             <Text>{t.mining.readyToMiningText}</Text>
             <Button
-              onClick={() => dispatch(actions.startMiningNode({ node: node }))}
+              onClick={() =>
+                dispatch(
+                  actions.startMiningNode({
+                    node,
+                    reason: MiningActionReason.Manual,
+                  }),
+                )
+              }
               disabled={disableActions}
               loading={disableActions}
               testId={`${node}-run-btn`}
@@ -246,7 +258,14 @@ const MiningBox = ({
           <MiningBoxContent data-testid='mining-box-paused-content'>
             {coins ? <CoinsList coins={coins} /> : null}
             <Button
-              onClick={() => dispatch(actions.startMiningNode({ node: node }))}
+              onClick={() =>
+                dispatch(
+                  actions.startMiningNode({
+                    node,
+                    reason: MiningActionReason.Manual,
+                  }),
+                )
+              }
               disabled={disableActions}
               loading={disableActions}
               testId={`${node}-run-btn`}
@@ -270,6 +289,7 @@ const MiningBox = ({
                 dispatch(
                   actions.stopMiningNode({
                     node,
+                    reason: MiningActionReason.Manual,
                   }),
                 )
               }

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/MiningTypeSelector/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/MiningTypeSelector/index.tsx
@@ -10,13 +10,16 @@ import t from '../../../../../locales'
  *
  * @prop {MiningNodeType[]} [value] - initial values of selected MiningNodeType
  * @prop {(v: MiningNodeType[]) => void} onChange - callback called when value of any checkbox changes
+ * @prop {MiningNodeType[]} miningTypesActive - which mining types can be chosen
  */
 const MiningTypeSelector = ({
   value,
   onChange,
+  miningTypesActive,
 }: {
   value: MiningNodeType[]
   onChange: (v: MiningNodeType[]) => void
+  miningTypesActive: MiningNodeType[]
 }) => {
   const theme = useTheme()
 
@@ -36,12 +39,14 @@ const MiningTypeSelector = ({
         checked={value.includes('tari')}
         onChange={() => toggle('tari')}
         style={{ marginBottom: theme.spacing(0.75) }}
+        disabled={!miningTypesActive.includes('tari')}
       >
         {t.common.miningType['tari']}
       </Checkbox>
       <Checkbox
         checked={value.includes('merged')}
         onChange={() => toggle('merged')}
+        disabled={!miningTypesActive.includes('merged')}
       >
         {t.common.miningType['merged']}
       </Checkbox>

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/RemoveSchedule/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/RemoveSchedule/index.tsx
@@ -21,7 +21,10 @@ const RemoveSchedule = ({ remove }: { remove: () => void }) => {
           <TrashIcon width='1em' height='1em' color={theme.secondary} />
         }
         onClick={remove}
-        style={{ paddingLeft: 0, display: 'inline' }}
+        style={{
+          paddingLeft: 0,
+          display: 'inline',
+        }}
       >
         <Text as='label' color={theme.secondary} style={{ cursor: 'pointer' }}>
           {t.mining.scheduling.removeSchedule}

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/index.test.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/index.test.tsx
@@ -1,11 +1,13 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { ThemeProvider } from 'styled-components'
 
-import { Schedule } from '../../../../types/general'
+import { Schedule, MiningNodeType } from '../../../../types/general'
 import themes from '../../../../styles/themes'
 import t from '../../../../locales'
 
 import ScheduleForm from './'
+
+const ALL_MINING_ACTIVE = ['tari', 'merged'] as MiningNodeType[]
 
 describe('ScheduleForm', () => {
   it('should not activate save button until mining type and schedule is selected', () => {
@@ -24,6 +26,7 @@ describe('ScheduleForm', () => {
           cancel={() => null}
           remove={() => null}
           onChange={onChange}
+          miningTypesActive={ALL_MINING_ACTIVE}
         />
       </ThemeProvider>,
     )
@@ -53,6 +56,7 @@ describe('ScheduleForm', () => {
           cancel={() => null}
           remove={() => null}
           onChange={() => null}
+          miningTypesActive={ALL_MINING_ACTIVE}
         />
       </ThemeProvider>,
     )
@@ -72,6 +76,7 @@ describe('ScheduleForm', () => {
           cancel={() => null}
           remove={remove}
           onChange={() => null}
+          miningTypesActive={ALL_MINING_ACTIVE}
         />
       </ThemeProvider>,
     )
@@ -100,6 +105,7 @@ describe('ScheduleForm', () => {
           cancel={() => null}
           remove={() => null}
           onChange={() => null}
+          miningTypesActive={ALL_MINING_ACTIVE}
         />
       </ThemeProvider>,
     )
@@ -131,6 +137,7 @@ describe('ScheduleForm', () => {
           cancel={cancel}
           remove={() => null}
           onChange={() => null}
+          miningTypesActive={ALL_MINING_ACTIVE}
         />
       </ThemeProvider>,
     )

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react'
 import { useTheme } from 'styled-components'
 
-import { Schedule, Interval } from '../../../../types/general'
+import { MiningNodeType, Schedule, Interval } from '../../../../types/general'
 import Button from '../../../../components/Button'
 import Box from '../../../../components/Box'
 import t from '../../../../locales'
@@ -37,17 +37,20 @@ const getIntervalWithZeros = (): Interval => {
  * @prop {() => void} cancel - callback for user action of cancelling editing
  * @prop {() => void} remove - callback for user action of removing edited schedule
  * @prop {(s: Schedule) => void} onChange - called with new Schedule after user accepts changes
+ * @prop {MiningNodeType[]} miningTypesActive - which mining types are correctly set up and can be scheduled
  */
 const ScheduleForm = ({
   value,
   cancel,
   onChange,
   remove,
+  miningTypesActive,
 }: {
   value?: Schedule
   cancel: () => void
   remove: () => void
   onChange: (s: Schedule) => void
+  miningTypesActive: MiningNodeType[]
 }) => {
   const editing = Boolean(value)
   const theme = useTheme()
@@ -98,7 +101,11 @@ const ScheduleForm = ({
           overflow: 'auto',
         }}
       >
-        <MiningTypeSelector value={miningType} onChange={setMiningType} />
+        <MiningTypeSelector
+          miningTypesActive={miningTypesActive}
+          value={miningType}
+          onChange={setMiningType}
+        />
         <DateScheduler
           days={days}
           date={date}

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/index.tsx
@@ -92,8 +92,10 @@ const ScheduleForm = ({
           flexDirection: 'column',
           width: '100%',
           padding: `${theme.spacing()} ${theme.spacing(1.5)}`,
-          paddingBottom: 0,
+          paddingBottom: theme.spacing(0.75),
           marginBottom: 0,
+          borderRadius: 0,
+          overflow: 'auto',
         }}
       >
         <MiningTypeSelector value={miningType} onChange={setMiningType} />

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/validation.test.ts
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/validation.test.ts
@@ -1,5 +1,6 @@
 import { Interval, Schedule } from '../../../../types/general'
 import t from '../../../../locales'
+import { startOfDay } from '../../../../utils/Date'
 
 import { validate } from './validation'
 import { utcTimeToString } from './utils'
@@ -77,6 +78,48 @@ describe('validate', () => {
       expect(error).toBeUndefined()
     })
 
+    /* eslint-disable-next-line quotes */
+    it(`should validate today's date if interval ends later than now`, () => {
+      const now = new Date('2022-05-12T12:00:00.000Z')
+      jest.useFakeTimers().setSystemTime(now)
+
+      const schedule: Schedule = {
+        id: Date.now().toString(),
+        enabled: true,
+        date: now,
+        interval: {
+          from: { hours: 11, minutes: 0 },
+          to: { hours: 12, minutes: 30 },
+        },
+        type: ['tari'],
+      }
+
+      const error = validate(schedule)
+
+      expect(error).toBeUndefined()
+    })
+
+    /* eslint-disable-next-line quotes */
+    it(`should validate today's date if interval is still in the future`, () => {
+      const now = new Date('2022-05-12T12:00:00.000Z')
+      jest.useFakeTimers().setSystemTime(now)
+
+      const schedule: Schedule = {
+        id: Date.now().toString(),
+        enabled: true,
+        date: now,
+        interval: {
+          from: { hours: 17, minutes: 23 },
+          to: { hours: 19, minutes: 12 },
+        },
+        type: ['tari'],
+      }
+
+      const error = validate(schedule)
+
+      expect(error).toBeUndefined()
+    })
+
     it('should return error for a date in the past', () => {
       const dateInThePast = new Date()
       dateInThePast.setDate(-1)
@@ -85,6 +128,27 @@ describe('validate', () => {
         id: Date.now().toString(),
         enabled: true,
         date: dateInThePast,
+        interval: {
+          from: { hours: 7, minutes: 23 },
+          to: { hours: 8, minutes: 12 },
+        },
+        type: ['tari'],
+      }
+
+      const error = validate(schedule)
+
+      expect(error).toBe(t.mining.scheduling.error_miningInThePast)
+    })
+
+    /* eslint-disable-next-line quotes */
+    it(`should return error for today's date but interval is in the past`, () => {
+      const now = new Date('2022-05-12T12:00:00.000Z')
+      jest.useFakeTimers().setSystemTime(now)
+
+      const schedule: Schedule = {
+        id: Date.now().toString(),
+        enabled: true,
+        date: now,
         interval: {
           from: { hours: 7, minutes: 23 },
           to: { hours: 8, minutes: 12 },

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/validation.ts
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/validation.ts
@@ -18,7 +18,7 @@ const validateInterval = (interval: Interval): string | undefined => {
   }
 }
 
-const validateDate = (date?: Date): string | undefined => {
+const validateDate = (interval: Interval, date?: Date): string | undefined => {
   if (!date) {
     return
   }
@@ -26,11 +26,26 @@ const validateDate = (date?: Date): string | undefined => {
   if (startOfUTCDay(date) < startOfUTCDay(new Date())) {
     return t.mining.scheduling.error_miningInThePast
   }
+
+  if (startOfUTCDay(date).getTime() === startOfUTCDay(new Date()).getTime()) {
+    if (interval.to.hours > date.getUTCHours()) {
+      return
+    }
+
+    if (
+      interval.to.hours === date.getUTCHours() &&
+      interval.to.minutes > date.getUTCMinutes()
+    ) {
+      return
+    }
+
+    return t.mining.scheduling.error_miningInThePast
+  }
 }
 
 export const validate = (schedule: Schedule): string | undefined => {
   const intervalError = validateInterval(schedule.interval)
-  const dateError = validateDate(schedule.date)
+  const dateError = validateDate(schedule.interval, schedule.date)
 
   return intervalError || dateError
 }

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/validation.ts
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/validation.ts
@@ -1,5 +1,5 @@
 import { Schedule, Interval } from '../../../../types/general'
-import { clearTime } from '../../../../utils/Date'
+import { startOfUTCDay } from '../../../../utils/Date'
 import t from '../../../../locales'
 
 const validateInterval = (interval: Interval): string | undefined => {
@@ -23,7 +23,7 @@ const validateDate = (date?: Date): string | undefined => {
     return
   }
 
-  if (clearTime(date) < clearTime(new Date())) {
+  if (startOfUTCDay(date) < startOfUTCDay(new Date())) {
     return t.mining.scheduling.error_miningInThePast
   }
 }

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/index.tsx
@@ -2,7 +2,11 @@ import { useState } from 'react'
 
 import Modal from '../../../components/Modal'
 import { useAppSelector, useAppDispatch } from '../../../store/hooks'
-import { selectSchedules, selectSchedule } from '../../../store/app/selectors'
+import {
+  selectSchedules,
+  selectSchedule,
+  selectActiveMiningTypes,
+} from '../../../store/app/selectors'
 import {
   toggleSchedule,
   removeSchedule,
@@ -31,6 +35,7 @@ const SchedulingContainer = ({
   const [editOpen, setEditOpen] = useState(false)
   const schedules = useAppSelector(selectSchedules)
   const scheduleToEdit = useAppSelector(selectSchedule(idToEdit))
+  const miningTypesActive = useAppSelector(selectActiveMiningTypes)
   const dispatch = useAppDispatch()
 
   const stopEditing = () => {
@@ -80,6 +85,7 @@ const SchedulingContainer = ({
               dispatch(updateSchedule({ value, scheduleId: value.id }))
               stopEditing()
             }}
+            miningTypesActive={miningTypesActive}
           />
         )}
       </ScheduleContainer>

--- a/applications/launchpad/gui-react/src/store/app/index.ts
+++ b/applications/launchpad/gui-react/src/store/app/index.ts
@@ -2,7 +2,7 @@ import { createSlice } from '@reduxjs/toolkit'
 
 import { ThemeType } from '../../styles/themes/types'
 import { Schedule } from '../../types/general'
-import { clearTime } from '../../utils/Date'
+import { startOfUTCDay } from '../../utils/Date'
 
 import { AppState, ExpertViewType, ViewType } from './types'
 
@@ -44,7 +44,7 @@ const appSlice = createSlice({
         ...rest,
       }
 
-      newSchedule.date = date ? clearTime(date).toISOString() : undefined
+      newSchedule.date = date ? startOfUTCDay(date).toISOString() : undefined
 
       state.schedules[scheduleId] = newSchedule
     },

--- a/applications/launchpad/gui-react/src/store/app/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/app/selectors.ts
@@ -2,7 +2,11 @@ import { createSelector } from '@reduxjs/toolkit'
 
 import { RootState } from '..'
 import themes from '../../styles/themes'
-import { Schedule } from '../../types/general'
+import { Schedule, MiningNodeType } from '../../types/general'
+import {
+  selectTariSetupRequired,
+  selectMergedSetupRequired,
+} from '../mining/selectors'
 
 export const selectExpertView = ({ app }: RootState) => app.expertView
 
@@ -43,3 +47,21 @@ export const selectSchedule =
       date: date && new Date(date),
     } as Schedule
   }
+
+export const selectActiveMiningTypes = createSelector(
+  selectTariSetupRequired,
+  selectMergedSetupRequired,
+  (tariSetupRequired, mergedSetupRequired) => {
+    const active = [] as MiningNodeType[]
+
+    if (!tariSetupRequired) {
+      active.push('tari')
+    }
+
+    if (!mergedSetupRequired) {
+      active.push('merged')
+    }
+
+    return active
+  },
+)

--- a/applications/launchpad/gui-react/src/store/app/types.ts
+++ b/applications/launchpad/gui-react/src/store/app/types.ts
@@ -1,5 +1,5 @@
 import { ThemeType } from '../../styles/themes/types'
-import { Schedule } from '../../types/general'
+import { Schedule, ScheduleId } from '../../types/general'
 
 export type ExpertViewType = 'hidden' | 'open' | 'fullscreen'
 export type ViewType = 'MINING' | 'BASE_NODE' | 'WALLET' | 'ONBOARDING'
@@ -8,5 +8,5 @@ export interface AppState {
   expertView: ExpertViewType
   view?: ViewType
   theme: ThemeType
-  schedules: Record<string, Omit<Schedule, 'date'> & { date?: string }>
+  schedules: Record<ScheduleId, Omit<Schedule, 'date'> & { date?: string }>
 }

--- a/applications/launchpad/gui-react/src/store/mining/index.ts
+++ b/applications/launchpad/gui-react/src/store/mining/index.ts
@@ -1,9 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { v4 as uuidv4 } from 'uuid'
-import { MiningNodeType } from '../../types/general'
+import { MiningNodeType, ScheduleId } from '../../types/general'
 
 import { startMiningNode, stopMiningNode } from './thunks'
-import { MiningState } from './types'
+import { MiningState, MiningActionReason } from './types'
 
 const currencies: Record<MiningNodeType, string[]> = {
   tari: ['xtr'],
@@ -43,8 +43,15 @@ const miningSlice = createSlice({
         ).toString()
       }
     },
-    startNewSession(state, action: PayloadAction<{ node: MiningNodeType }>) {
-      const { node } = action.payload
+    startNewSession(
+      state,
+      action: PayloadAction<{
+        node: MiningNodeType
+        reason: MiningActionReason
+        schedule?: ScheduleId
+      }>,
+    ) {
+      const { node, reason, schedule } = action.payload
       const total: Record<string, string> = {}
       currencies[node].forEach(c => {
         total[c] = '0'
@@ -54,14 +61,23 @@ const miningSlice = createSlice({
         id: uuidv4(),
         startedAt: Number(Date.now()).toString(),
         total,
+        reason,
+        schedule,
       }
     },
-    stopSession(state, action: PayloadAction<{ node: MiningNodeType }>) {
-      const { node } = action.payload
+    stopSession(
+      state,
+      action: PayloadAction<{
+        node: MiningNodeType
+        reason: MiningActionReason
+      }>,
+    ) {
+      const { node, reason } = action.payload
 
       const session = state[node].session
       if (session) {
         session.finishedAt = Number(Date.now()).toString()
+        session.reason = reason
       }
     },
     setMergedAddress(state, action: PayloadAction<{ address: string }>) {

--- a/applications/launchpad/gui-react/src/store/mining/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/mining/thunks.ts
@@ -8,6 +8,24 @@ import { Container } from '../containers/types'
 import { RootState } from '..'
 
 import { MiningActionReason } from './types'
+import { selectTariSetupRequired, selectMergedSetupRequired } from './selectors'
+
+const checkSetup: Record<MiningNodeType, (state: RootState) => void> = {
+  tari: state => {
+    const setupRequired = selectTariSetupRequired(state)
+
+    if (setupRequired) {
+      throw setupRequired
+    }
+  },
+  merged: state => {
+    const setupRequired = selectMergedSetupRequired(state)
+
+    if (setupRequired) {
+      throw setupRequired
+    }
+  },
+}
 
 /**
  * Start given mining node. It spawns all dependencies if needed.
@@ -21,6 +39,8 @@ export const startMiningNode = createAsyncThunk<
 >('mining/startNode', async ({ node, reason, schedule }, thunkApi) => {
   try {
     const rootState = thunkApi.getState()
+
+    checkSetup[node](rootState)
 
     const miningSession = rootState.mining[node].session
     const scheduledMiningWasStoppedManually =

--- a/applications/launchpad/gui-react/src/store/mining/types.ts
+++ b/applications/launchpad/gui-react/src/store/mining/types.ts
@@ -1,3 +1,4 @@
+import { ScheduleId } from '../../types/general'
 import {
   ContainerStateFields,
   Container,
@@ -20,11 +21,18 @@ export interface MiningDependencyState {
   error: boolean
 }
 
+export enum MiningActionReason {
+  Schedule = 'schedule',
+  Manual = 'manual',
+}
+
 export interface MiningSession {
   startedAt?: string // UTC timestamp
   finishedAt?: string
   id?: string // uuid (?)
   total?: Record<string, string> // i,e { xtr: 1000 bignumber (?) }
+  reason: MiningActionReason
+  schedule?: ScheduleId
 }
 
 export interface MiningNodeState {

--- a/applications/launchpad/gui-react/src/types/general.ts
+++ b/applications/launchpad/gui-react/src/types/general.ts
@@ -15,8 +15,9 @@ export type Interval = {
   to: Time
 }
 
+export type ScheduleId = string
 export type Schedule = {
-  id: string
+  id: ScheduleId
   enabled: boolean
   days?: number[]
   date?: Date

--- a/applications/launchpad/gui-react/src/useMiningScheduling/getStartsStops.test.ts
+++ b/applications/launchpad/gui-react/src/useMiningScheduling/getStartsStops.test.ts
@@ -34,6 +34,7 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T17:00:00.000Z'),
         stop: new Date('2022-05-21T18:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'scheduleId',
       },
     ]
 
@@ -76,6 +77,7 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T12:00:00.000Z'),
         stop: new Date('2022-05-21T18:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'scheduleId',
       },
     ]
 
@@ -118,6 +120,7 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T09:00:00.000Z'),
         stop: new Date('2022-05-21T12:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'scheduleId',
       },
     ]
 
@@ -197,11 +200,13 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T17:00:00.000Z'),
         stop: new Date('2022-05-21T18:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'scheduleId',
       },
       {
         start: new Date('2022-05-21T17:00:00.000Z'),
         stop: new Date('2022-05-21T18:00:00.000Z'),
         toMine: 'merged',
+        scheduleId: 'scheduleId',
       },
     ]
 
@@ -261,6 +266,7 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T17:00:00.000Z'),
         stop: new Date('2022-05-21T18:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'scheduleId',
       },
     ]
 
@@ -321,6 +327,7 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T17:00:00.000Z'),
         stop: new Date('2022-05-21T18:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'scheduleId',
       },
     ]
 
@@ -380,6 +387,7 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T16:00:00.000Z'),
         stop: new Date('2022-05-21T18:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'otherScheduleId',
       },
     ]
 
@@ -439,6 +447,7 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T16:00:00.000Z'),
         stop: new Date('2022-05-21T19:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'otherScheduleId',
       },
     ]
 
@@ -514,16 +523,19 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T13:00:00.000Z'),
         stop: new Date('2022-05-21T14:40:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'otherScheduleId',
       },
       {
         start: new Date('2022-05-21T16:50:00.000Z'),
         stop: new Date('2022-05-21T20:00:00.000Z'),
         toMine: 'merged',
+        scheduleId: 'anotherScheduleId',
       },
       {
         start: new Date('2022-05-21T17:00:00.000Z'),
         stop: new Date('2022-05-21T18:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'scheduleId',
       },
     ]
 
@@ -599,11 +611,13 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T08:00:00.000Z'),
         stop: new Date('2022-05-21T11:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'todayEarly',
       },
       {
         start: new Date('2022-05-21T19:00:00.000Z'),
         stop: new Date('2022-05-21T20:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'onSaturdaysLate',
       },
     ]
 
@@ -664,26 +678,31 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T08:00:00.000Z'),
         stop: new Date('2022-05-21T11:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'early',
       },
       {
         start: new Date('2022-05-21T19:00:00.000Z'),
         stop: new Date('2022-05-21T20:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'onSaturdaysLate',
       },
       {
         start: new Date('2022-05-22T08:00:00.000Z'),
         stop: new Date('2022-05-22T11:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'early',
       },
       {
         start: new Date('2022-05-23T08:00:00.000Z'),
         stop: new Date('2022-05-23T11:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'early',
       },
       {
         start: new Date('2022-05-23T19:00:00.000Z'),
         stop: new Date('2022-05-23T20:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'onSaturdaysLate',
       },
     ]
 
@@ -760,11 +779,13 @@ describe('getStartsStops', () => {
         start: new Date('2022-05-21T08:00:00.000Z'),
         stop: new Date('2022-05-21T12:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'first',
       },
       {
         start: new Date('2022-05-22T08:00:00.000Z'),
         stop: new Date('2022-05-22T13:00:00.000Z'),
         toMine: 'tari',
+        scheduleId: 'first',
       },
     ]
 

--- a/applications/launchpad/gui-react/src/useMiningScheduling/getStartsStops.test.ts
+++ b/applications/launchpad/gui-react/src/useMiningScheduling/getStartsStops.test.ts
@@ -1,5 +1,5 @@
 import { Schedule } from '../types/general'
-import { clearTime } from '../utils/Date'
+import { startOfUTCDay } from '../utils/Date'
 
 import { StartStop } from './types'
 import { getStartsStops } from './getStartsStops'
@@ -57,7 +57,7 @@ describe('getStartsStops', () => {
       {
         id: 'scheduleId',
         enabled: true,
-        date: clearTime(from),
+        date: startOfUTCDay(from),
         interval: {
           from: {
             hours: 12,
@@ -99,7 +99,7 @@ describe('getStartsStops', () => {
       {
         id: 'scheduleId',
         enabled: true,
-        date: clearTime(from),
+        date: startOfUTCDay(from),
         interval: {
           from: {
             hours: 7,
@@ -141,7 +141,7 @@ describe('getStartsStops', () => {
       {
         id: 'scheduleId',
         enabled: true,
-        date: clearTime(from),
+        date: startOfUTCDay(from),
         interval: {
           from: {
             hours: 7,

--- a/applications/launchpad/gui-react/src/useMiningScheduling/getStartsStops.ts
+++ b/applications/launchpad/gui-react/src/useMiningScheduling/getStartsStops.ts
@@ -1,13 +1,16 @@
 import { Schedule } from '../types/general'
-import { clearTime, dateInside } from '../utils/Date'
+import { startOfUTCDay, dateInside } from '../utils/Date'
 
 import { StartStop } from './types'
 
 const getDaysBetween = (from: Date, to: Date) => {
   const days: Date[] = []
-  let currentDay = clearTime(from)
+  let currentDay = startOfUTCDay(from)
 
-  while (clearTime(currentDay).getTime() < clearTime(to).getTime() + 1) {
+  while (
+    startOfUTCDay(currentDay).getTime() <
+    startOfUTCDay(to).getTime() + 1
+  ) {
     days.push(new Date(currentDay))
 
     currentDay = new Date(currentDay.setUTCDate(currentDay.getUTCDate() + 1))
@@ -65,11 +68,11 @@ export const getStartsStops = ({
 
   return [...enabledSchedulesWithDates, ...schedulesGeneratedFromDays]
     .filter(schedule => {
-      const scheduleStart = clearTime(new Date(schedule.date!))
+      const scheduleStart = startOfUTCDay(new Date(schedule.date!))
       scheduleStart.setUTCHours(schedule.interval.from.hours)
       scheduleStart.setUTCMinutes(schedule.interval.from.minutes)
 
-      const scheduleStop = clearTime(new Date(schedule.date!))
+      const scheduleStop = startOfUTCDay(new Date(schedule.date!))
       scheduleStop.setUTCHours(schedule.interval.to.hours)
       scheduleStop.setUTCMinutes(schedule.interval.to.minutes)
 
@@ -80,11 +83,11 @@ export const getStartsStops = ({
     })
     .flatMap(schedule =>
       schedule.type.map(miningType => {
-        const startTime = clearTime(new Date(schedule.date!))
+        const startTime = startOfUTCDay(new Date(schedule.date!))
         startTime.setUTCHours(schedule.interval.from.hours)
         startTime.setUTCMinutes(schedule.interval.from.minutes)
 
-        const stopTime = clearTime(new Date(schedule.date!))
+        const stopTime = startOfUTCDay(new Date(schedule.date!))
         stopTime.setUTCHours(schedule.interval.to.hours)
         stopTime.setUTCMinutes(schedule.interval.to.minutes)
 

--- a/applications/launchpad/gui-react/src/useMiningScheduling/getStartsStops.ts
+++ b/applications/launchpad/gui-react/src/useMiningScheduling/getStartsStops.ts
@@ -95,6 +95,7 @@ export const getStartsStops = ({
           start: startTime.getTime() < from.getTime() ? from : startTime,
           stop: stopTime,
           toMine: miningType,
+          scheduleId: schedule.id,
         }
       }),
     )

--- a/applications/launchpad/gui-react/src/useMiningScheduling/index.ts
+++ b/applications/launchpad/gui-react/src/useMiningScheduling/index.ts
@@ -1,36 +1,51 @@
 import { useCallback, useRef } from 'react'
 
-import { MiningNodeType } from '../types/general'
+import { MiningNodeType, ScheduleId } from '../types/general'
 import { useAppSelector, useAppDispatch } from '../store/hooks'
 import { selectSchedules } from '../store/app/selectors'
 import { actions as miningActions } from '../store/mining'
 
 import useMiningScheduling from './useMiningScheduling'
+import { MiningActionReason } from '../store/mining/types'
 
 /**
  * @name useMiningSchedulingContainer
  * @description connects mining scheduling to the store
- *
  */
 const useMiningSchedulingContainer = () => {
   const dispatch = useAppDispatch()
   const schedules = useAppSelector(selectSchedules)
   const startPending = useRef<boolean>(false)
-  const startMining = useCallback(async (node: MiningNodeType) => {
-    if (startPending.current) {
-      return
-    }
+  const startMining = useCallback(
+    async (node: MiningNodeType, schedule: ScheduleId) => {
+      if (startPending.current) {
+        return
+      }
 
-    try {
-      startPending.current = true
-      await dispatch(miningActions.startMiningNode({ node })).unwrap()
-      startPending.current = false
-    } finally {
-      startPending.current = false
-    }
-  }, [])
+      try {
+        startPending.current = true
+        await dispatch(
+          miningActions.startMiningNode({
+            node,
+            reason: MiningActionReason.Schedule,
+            schedule,
+          }),
+        ).unwrap()
+        startPending.current = false
+      } finally {
+        startPending.current = false
+      }
+    },
+    [],
+  )
   const stopMining = useCallback(
-    (node: MiningNodeType) => dispatch(miningActions.stopMiningNode({ node })),
+    (node: MiningNodeType) =>
+      dispatch(
+        miningActions.stopMiningNode({
+          node,
+          reason: MiningActionReason.Schedule,
+        }),
+      ),
     [],
   )
 

--- a/applications/launchpad/gui-react/src/useMiningScheduling/types.ts
+++ b/applications/launchpad/gui-react/src/useMiningScheduling/types.ts
@@ -1,7 +1,8 @@
-import { MiningNodeType } from '../types/general'
+import { MiningNodeType, ScheduleId } from '../types/general'
 
 export type StartStop = {
   start: Date
   stop: Date
   toMine: MiningNodeType
+  scheduleId: ScheduleId
 }

--- a/applications/launchpad/gui-react/src/useMiningScheduling/useMiningScheduling.test.ts
+++ b/applications/launchpad/gui-react/src/useMiningScheduling/useMiningScheduling.test.ts
@@ -49,8 +49,8 @@ describe('useMiningScheduling', () => {
     // then
     jest.advanceTimersByTime(A_MINUTE + 1)
     expect(startMining).toHaveBeenCalledTimes(2)
-    expect(startMining).toHaveBeenCalledWith('tari')
-    expect(startMining).toHaveBeenCalledWith('merged')
+    expect(startMining).toHaveBeenCalledWith('tari', 'shortSchedule')
+    expect(startMining).toHaveBeenCalledWith('merged', 'shortSchedule')
 
     jest.advanceTimersByTime(A_MINUTE)
     expect(stopMining).toHaveBeenCalledTimes(2)

--- a/applications/launchpad/gui-react/src/useMiningScheduling/useMiningScheduling.test.ts
+++ b/applications/launchpad/gui-react/src/useMiningScheduling/useMiningScheduling.test.ts
@@ -1,8 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks'
 
 import { Schedule } from '../types/general'
-import { clearTime } from '../utils/Date'
 import { createPeriodicalGetNow } from '../utils/testUtils'
+import { startOfUTCDay } from '../utils/Date'
 
 import useMiningScheduling from './useMiningScheduling'
 
@@ -21,7 +21,7 @@ describe('useMiningScheduling', () => {
       {
         id: 'shortSchedule',
         enabled: true,
-        date: clearTime(now),
+        date: startOfUTCDay(now),
         interval: {
           from: {
             hours: 9,
@@ -70,7 +70,7 @@ describe('useMiningScheduling', () => {
       {
         id: 'shortSchedule',
         enabled: true,
-        date: clearTime(dayFromNow),
+        date: startOfUTCDay(dayFromNow),
         interval: {
           from: {
             hours: 9,

--- a/applications/launchpad/gui-react/src/useMiningScheduling/useMiningScheduling.ts
+++ b/applications/launchpad/gui-react/src/useMiningScheduling/useMiningScheduling.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
 
 import { startOfMinute } from '../utils/Date'
-import { MiningNodeType, Schedule } from '../types/general'
+import { MiningNodeType, Schedule, ScheduleId } from '../types/general'
 import useScheduling from '../utils/useScheduling'
 
 import { getStartsStops } from './getStartsStops'
@@ -19,7 +19,7 @@ const TWENTY_FOUR_HOURS_IN_MS = 24 * 60 * 60 * 1000
  * by default it calculates mining starts/stops for next 24h and will recalculate after that period
  *
  * @prop {Schedule[]} schedules - user-defined mining schedules
- * @prop {(miningType: MiningNodeType) => void} startMining - callback for mining start
+ * @prop {(miningType: MiningNodeType, schedule: ScheduleId) => void} startMining - callback for mining start
  * @prop {(miningType: MiningNodeType) => void} stopMining - callback for mining stop
  * @prop {() => Date} [getNow] - time provider that has a default value of () => new Date(), introduced mostly for easier mocking in testing
  * @prop {number} [singleSchedulingPeriod] - length of time that hook should calculate schedules for (default is 24h)
@@ -32,7 +32,7 @@ const useMiningScheduling = ({
   singleSchedulingPeriod = TWENTY_FOUR_HOURS_IN_MS,
 }: {
   schedules: Schedule[]
-  startMining: (miningType: MiningNodeType) => void
+  startMining: (miningType: MiningNodeType, schedule: ScheduleId) => void
   stopMining: (miningType: MiningNodeType) => void
   getNow?: () => Date
   singleSchedulingPeriod?: number
@@ -88,7 +88,7 @@ const useMiningScheduling = ({
         ss => startOfMinute(ss.stop).getTime() === startOfMinute(now).getTime(),
       )
 
-      starts.forEach(start => startMining(start.toMine))
+      starts.forEach(start => startMining(start.toMine, start.scheduleId))
       stops.forEach(stop => stopMining(stop.toMine))
     },
     [startStops, startMining, stopMining],

--- a/applications/launchpad/gui-react/src/utils/Date.ts
+++ b/applications/launchpad/gui-react/src/utils/Date.ts
@@ -35,7 +35,18 @@ export const isCurrentMonth = (d: Date) => {
   )
 }
 
-export const clearTime = (d: Date) => {
+export const startOfDay = (d: Date) => {
+  const copy = new Date(d)
+
+  copy.setHours(0)
+  copy.setMinutes(0)
+  copy.setSeconds(0)
+  copy.setMilliseconds(0)
+
+  return copy
+}
+
+export const startOfUTCDay = (d: Date) => {
   const copy = new Date(d)
 
   copy.setUTCHours(0)


### PR DESCRIPTION
Description
---

- [x] fix calendar picker (today is not pickable)
- [x] fix add schedule form error display (duplicated buttons)
- [x] add manual overrides
- [x] disable checkboxes if mining type is not setup correctly
- [x] when specific date is picked for schedule, make sure that interval is not entirely in the past
- [x] do not attempt to schedule when mining type used is not setup correctly // is this even possible?

Motivation and Context
---

#43 

How Has This Been Tested?
---

