### PR TITLE
spike: collecting logs and allowing querying

### DIFF
--- a/applications/launchpad/backend/src/docker/workspace.rs
+++ b/applications/launchpad/backend/src/docker/workspace.rs
@@ -392,6 +392,10 @@ impl TariWorkspace {
                 mounts: Some(mounts),
                 ..Default::default()
             }),
+            labels: Some(HashMap::from([
+                (String::from("tari"), String::from("yes")),
+                (String::from("tari_service"), String::from(image.image_name())),
+            ])),
             networking_config: Some(NetworkingConfig {
                 endpoints_config: endpoints,
             }),

--- a/applications/launchpad/docker_rig/docker-compose.loki.yml
+++ b/applications/launchpad/docker_rig/docker-compose.loki.yml
@@ -1,0 +1,25 @@
+version: "3.9"
+services:
+  loki:
+    image: grafana/loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
+  logspout:
+    image: bekt/logspout-logstash
+    restart: on-failure
+    environment:
+      - ROUTE_URIS=logstash://logstash:5000?filter.labels=tari:yes # this filters logspout to only listen to containers with label tari with value yes
+      - ALLOW_TTY=true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    depends_on:
+      - logstash
+
+  logstash:
+    image: grafana/logstash-output-loki
+    restart: on-failure
+    volumes:
+      - ./logstash/:/usr/share/logstash/config
+    command: -f /usr/share/logstash/config/loki.conf

--- a/applications/launchpad/docker_rig/logstash/logstash.yml
+++ b/applications/launchpad/docker_rig/logstash/logstash.yml
@@ -1,0 +1,4 @@
+pipeline:
+    batch:
+        size: 125
+        delay: 50

--- a/applications/launchpad/docker_rig/logstash/loki.conf
+++ b/applications/launchpad/docker_rig/logstash/loki.conf
@@ -1,0 +1,80 @@
+input {
+  udp {
+    port  => 5000
+    codec => json
+  }
+  tcp {
+    port  => 5000
+    codec => json
+  }
+}
+
+filter {
+  if [docker][image] =~ /tor/ {
+    mutate {
+      add_field => {
+        "tari_service" => "tor"
+      }
+    }
+  }
+
+  if [docker][image] =~ /tari_base_node/ {
+    mutate {
+      add_field => {
+        "tari_service" => "base_node"
+      }
+    }
+  }
+
+  # TODO rest of services
+  # if [docker][image] =~ /tari_base_node/ {
+    # mutate {
+      # add_field => {
+        # "tari_service" => "base_node"
+      # }
+    # }
+  # }
+}
+
+filter {
+  mutate {
+    add_field => {
+      "job" => "logstash"
+    }
+    replace => { "type" => "stream"}
+  }
+}
+
+output {
+  loki {
+    url => "http://loki:3100/loki/api/v1/push"
+
+    # [tenant_id => string | default = nil | required=false]
+
+    # [message_field => string | default = "message" | required=false]
+
+    # [include_fields => array | default = [] | required=false]
+
+    # [batch_wait => number | default = 1(s) | required=false]
+
+    # [batch_size => number | default = 102400(bytes) | required=false]
+
+    # [min_delay => number | default = 1(s) | required=false]
+
+    # [max_delay => number | default = 300(s) | required=false]
+
+    # [retries => number | default = 10 | required=false]
+
+    # [username => string | default = nil | required=false]
+
+    # [password => secret | default = nil | required=false]
+
+    # [cert => path | default = nil | required=false]
+
+    # [key => path | default = nil| required=false]
+
+    # [ca_cert => path | default = nil | required=false]
+
+    # [insecure_skip_verify => boolean | default = false | required=false]
+  }
+}


### PR DESCRIPTION
Description
---
how to use:
1. run `docker-compose -f docker-compose.loki.yml up -d` in `docker_rig`
1. start `tari_launchpad`
1. start any container from launchpad
1. see logs under http://localhost:3100/loki/api/v1/query_range?query={job=%22logstash%22}&start=1653823389381999872

Motivation and Context
---

#206
this can allow our backend to provide an api endpoint to frontend for log querying (LogQL queries from frontend, based on labels setup in logstash)

How Has This Been Tested?
---
 
??