### PR TITLE
feat(launchpad): stream wallet events to front-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6819,9 +6819,11 @@ dependencies = [
  "chrono",
  "clap 3.1.8",
  "config",
+ "crossbeam",
  "crossterm 0.17.7",
  "digest 0.9.0",
  "futures 0.3.21",
+ "lazy_static",
  "log",
  "opentelemetry",
  "opentelemetry-jaeger",
@@ -7043,6 +7045,7 @@ dependencies = [
 name = "tari_launchpad"
 version = "0.32.3"
 dependencies = [
+ "async-trait",
  "bollard",
  "config",
  "derivative",
@@ -7056,13 +7059,17 @@ dependencies = [
  "serde_json",
  "strum 0.23.0",
  "strum_macros 0.23.1",
+ "tari_app_grpc",
  "tari_app_utilities",
  "tari_common",
+ "tari_common_types",
  "tari_comms",
  "tauri",
  "tauri-build",
  "thiserror",
  "tokio 1.17.0",
+ "tokio-stream",
+ "tonic",
  "tor-hash-passwd",
 ]
 

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -82,6 +82,8 @@ service Wallet {
     rpc GetOwnedTokens(GetOwnedTokensRequest) returns (GetOwnedTokensResponse);
 
     rpc SetBaseNode(SetBaseNodeRequest) returns (SetBaseNodeResponse);
+
+    rpc StreamTransactionEvents(TransactionEventRequest) returns (stream TransactionEventResponse);
 }
 
 message GetVersionRequest { }
@@ -369,4 +371,23 @@ message CheckConnectivityResponse{
         Offline = 2;
     }
     OnlineStatus status = 1;
+}
+
+message TransactionEventRequest{
+
+}
+
+message TransactionEvent {
+    string event = 1;
+    uint64 tx_id = 2;
+    bytes source_pk = 3;
+    bytes dest_pk = 4;
+    string status = 5;
+    string direction = 6;
+    uint64 amount = 7;
+    string message = 8;
+}
+
+message TransactionEventResponse {
+    TransactionEvent transaction  = 1;
 }

--- a/applications/tari_app_grpc/src/conversions/transaction.rs
+++ b/applications/tari_app_grpc/src/conversions/transaction.rs
@@ -30,7 +30,7 @@ use tari_core::transactions::transaction_components::Transaction;
 use tari_crypto::ristretto::RistrettoSecretKey;
 use tari_utilities::ByteArray;
 
-use crate::tari_rpc as grpc;
+use crate::tari_rpc::{self as grpc, TransactionEvent};
 
 impl TryFrom<Transaction> for grpc::Transaction {
     type Error = String;
@@ -82,6 +82,35 @@ impl From<TransactionDirection> for grpc::TransactionDirection {
             Unknown => grpc::TransactionDirection::Unknown,
             Inbound => grpc::TransactionDirection::Inbound,
             Outbound => grpc::TransactionDirection::Outbound,
+        }
+    }
+}
+
+impl From<String> for grpc::TransactionDirection {
+    fn from(status: String) -> Self {
+        match status.to_lowercase().as_str() {
+            "inbound" => grpc::TransactionDirection::Inbound,
+            "outbound" => grpc::TransactionDirection::Outbound,
+            _ => grpc::TransactionDirection::Unknown,
+        }
+    }
+}
+
+impl From<String> for grpc::TransactionStatus {
+    fn from(status: String) -> Self {
+        match status.to_lowercase().as_str() {
+            "completed" => grpc::TransactionStatus::Completed,
+            "broadcast" => grpc::TransactionStatus::Broadcast,
+            "minedUnconfirmed" => grpc::TransactionStatus::MinedUnconfirmed,
+            "minedConfirmed" => grpc::TransactionStatus::MinedConfirmed,
+            "imported" => grpc::TransactionStatus::Imported,
+            "pending" => grpc::TransactionStatus::Pending,
+            "coinbase" => grpc::TransactionStatus::Coinbase,
+            "rejected" => grpc::TransactionStatus::Rejected,
+            "fauxUnconfirmed" => grpc::TransactionStatus::FauxUnconfirmed,
+            "fauxConfirmed" => grpc::TransactionStatus::FauxConfirmed,
+            "queued" => grpc::TransactionStatus::Queued,
+            _ => grpc::TransactionStatus::NotFound,
         }
     }
 }

--- a/applications/tari_console_wallet/Cargo.toml
+++ b/applications/tari_console_wallet/Cargo.toml
@@ -33,7 +33,9 @@ config = "0.13.0"
 chrono = { version = "0.4.19", default-features = false }
 bitflags = "1.2.1"
 futures = { version = "^0.3.16", default-features = false, features = ["alloc"] }
+crossbeam = "0.8.1"
 crossterm = { version = "0.17" }
+lazy_static = "1.3.0"
 rand = "0.8"
 unicode-width = "0.1"
 unicode-segmentation = "1.6.0"

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -19,11 +19,18 @@
 //  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 //  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 //  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#[macro_use]
+extern crate lazy_static;
+
+lazy_static! {
+    static ref EVENT_LISTENER: (Sender<Vec<String>>, Receiver<Vec<String>>) = crossbeam::channel::unbounded();
+}
 
 use std::{env, process};
 
 use clap::Parser;
 use cli::Cli;
+use crossbeam::channel::{Receiver, Sender};
 use init::{
     boot,
     change_password,


### PR DESCRIPTION
Description

Provide a new Tari event stream for:
	- transaction received (source: wallet)
	- transaction sent (source: wallet)
	- transaction cancelled (source: wallet)
	- transaction mined but unconfirmed (source: wallet)
	- transaction mined and confirmed (source: wallet)

Expose a streaming interface for all data we log using.
Create grpc TransactionEvent model and implement grpc streaming endpoint.
Forward logging data from notifier(app. logger) to the grpc streaming service.
Map the logging data to TransactionEvent model (Vec<String> -> TransactionEvent)

Motivation and Context
The launchpad users want to see the actual mining progress and all mining relalted events on the UI.
Hence we should forward the data/log streams from the underlying apps to the front-end.

How Has This Been Tested?

!!! TO_DO: The change IS NOT TESTED.
The change should be tested manually along with base node, tor, and launchpad.