### PR TITLE
feat(launchpad): stream wallet events to front-end

### DIFF
--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -82,6 +82,8 @@ service Wallet {
     rpc GetOwnedTokens(GetOwnedTokensRequest) returns (GetOwnedTokensResponse);
 
     rpc SetBaseNode(SetBaseNodeRequest) returns (SetBaseNodeResponse);
+
+    rpc StreamTransactionEvents(TransactionEventRequest) returns (stream TransactionEventResponse);
 }
 
 message GetVersionRequest { }
@@ -369,4 +371,23 @@ message CheckConnectivityResponse{
         Offline = 2;
     }
     OnlineStatus status = 1;
+}
+
+message TransactionEventRequest{
+
+}
+
+message TransactionEvent {
+    string event = 1;
+    string tx_id = 2;
+    bytes source_pk = 3;
+    bytes dest_pk = 4;
+    string status = 5;
+    string direction = 6;
+    uint64 amount = 7;
+    string message = 8;
+}
+
+message TransactionEventResponse {
+    TransactionEvent transaction  = 1;
 }

--- a/applications/tari_console_wallet/src/grpc/mod.rs
+++ b/applications/tari_console_wallet/src/grpc/mod.rs
@@ -3,4 +3,53 @@
 
 mod wallet_grpc_server;
 
+use tari_app_grpc::tari_rpc::TransactionEvent;
+use tari_utilities::hex::Hex;
+use tari_wallet::transaction_service::storage::models::{
+    CompletedTransaction,
+    InboundTransaction,
+    OutboundTransaction,
+};
+
 pub use self::wallet_grpc_server::*;
+
+pub enum TransactionWrapper {
+    Completed(CompletedTransaction),
+    Outbound(OutboundTransaction),
+    Inbound(InboundTransaction),
+}
+
+pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -> TransactionEvent {
+    match source {
+        TransactionWrapper::Completed(completed) => TransactionEvent {
+            event,
+            tx_id: completed.tx_id.to_string(),
+            source_pk: completed.source_public_key.to_hex().into_bytes(),
+            dest_pk: completed.destination_public_key.to_hex().into_bytes(),
+            status: completed.status.to_string(),
+            direction: completed.direction.to_string(),
+            amount: completed.amount.as_u64(),
+            message: completed.message,
+        },
+        TransactionWrapper::Outbound(outbound) => TransactionEvent {
+            event,
+            tx_id: outbound.tx_id.to_string(),
+            source_pk: vec![],
+            dest_pk: outbound.destination_public_key.to_hex().into_bytes(),
+            status: outbound.status.to_string(),
+            direction: "outbound".to_string(),
+            amount: outbound.amount.as_u64(),
+            message: outbound.message,
+        },
+        TransactionWrapper::Inbound(inbound) => TransactionEvent {
+            event,
+            tx_id: inbound.tx_id.to_string(),
+            source_pk: inbound.source_public_key.to_hex().into_bytes(),
+            dest_pk: vec![],
+            status: inbound.status.to_string(),
+            direction: "inbound".to_string(),
+            amount: inbound.amount.as_u64(),
+            message: inbound.message,
+        },
+    }
+}

--- a/applications/tari_console_wallet/src/main.rs
+++ b/applications/tari_console_wallet/src/main.rs
@@ -65,7 +65,6 @@ mod ui;
 mod utils;
 mod wallet_modes;
 
-/// Application entry point
 fn main() {
     // Uncomment to enable tokio tracing via tokio-console
     // console_subscriber::init();

--- a/applications/tari_console_wallet/src/wallet_modes.rs
+++ b/applications/tari_console_wallet/src/wallet_modes.rs
@@ -19,6 +19,7 @@
 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
 // WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 use std::{fs, io::Stdout, path::PathBuf};
 
 use log::*;
@@ -26,7 +27,7 @@ use rand::{rngs::OsRng, seq::SliceRandom};
 use tari_common::exit_codes::{ExitCode, ExitError};
 use tari_comms::{multiaddr::Multiaddr, peer_manager::Peer, utils::multiaddr::multiaddr_to_socketaddr};
 use tari_wallet::{WalletConfig, WalletSqlite};
-use tokio::runtime::Handle;
+use tokio::{runtime::Handle, sync::broadcast};
 use tonic::transport::Server;
 use tui::backend::CrosstermBackend;
 
@@ -40,7 +41,6 @@ use crate::{
     ui::App,
     utils::db::get_custom_base_node_peer_from_db,
 };
-
 pub const LOG_TARGET: &str = "wallet::app::main";
 
 #[derive(Debug, Clone)]
@@ -243,12 +243,18 @@ pub fn tui_mode(
     base_node_config: &PeerConfig,
     mut wallet: WalletSqlite,
 ) -> Result<(), ExitError> {
+    let (events_broadcaster, _events_listener) = broadcast::channel(100);
     if let Some(ref grpc_address) = config.grpc_address {
         let grpc = WalletGrpcServer::new(wallet.clone());
         handle.spawn(run_grpc(grpc, grpc_address.clone()));
     }
 
-    let notifier = Notifier::new(config.notify_file.clone(), handle.clone(), wallet.clone());
+    let notifier = Notifier::new(
+        config.notify_file.clone(),
+        handle.clone(),
+        wallet.clone(),
+        events_broadcaster,
+    );
 
     let base_node_selected;
     if let Some(peer) = base_node_config.base_node_custom.clone() {


### PR DESCRIPTION
Description

Provide a new Tari event stream for:
	- transaction received (source: wallet)
	- transaction sent (source: wallet)
	- transaction cancelled (source: wallet)
	- transaction mined but unconfirmed (source: wallet)
	- transaction mined and confirmed (source: wallet)

Expose a streaming interface for all data we log using.
Read all events from database and stream them over grpc streaming endpoint.


Motivation and Context
The launchpad users want to see the actual mining progress and all mining relalted events on the UI.
Hence we should forward the data/log streams from the underlying apps to the front-end.


How Has This Been Tested?

!!! TO_DO: The change IS NOT TESTED.
The change should be tested manually along with base node, tor, and launchpad.
