### PR TITLE
chore: build gui-react in launchpad ci

### DIFF
--- a/.github/workflows/launchpad_v2.yml
+++ b/.github/workflows/launchpad_v2.yml
@@ -58,11 +58,11 @@ jobs:
         run: |
           cd applications/launchpad/gui-react
           yarn test:ci
-      - name: yarn tauri build
+      - name: gui-react build
         run: |
-          cd applications/launchpad
+          cd applications/launchpad/gui-react
           yarn install
-          yarn tauri build
+          yarn build
       - name: Upload the test coverage
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/launchpad_v2_nightly.yml
+++ b/.github/workflows/launchpad_v2_nightly.yml
@@ -1,20 +1,11 @@
-name: Launchpad v2 CI
-
+# Runs daily
+name: Launchpad v2 NPM audit
 on:
-  push:
-    branches:
-      - launchpad_such_wow
-  pull_request:
-    branches:
-      - "launchpad**"
-    types:
-      - opened
-      - reopened
-      - synchronize
-
+  schedule:
+    - cron: "0 1 * * *"
 jobs:
-  launchpad-v2-ci:
-    name: test launchpad_v2
+  launchpad-v2-nightly:
+    name: build launchpad_v2
     runs-on: ubuntu-18.04
     steps:
       - name: checkout
@@ -23,11 +14,29 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: "16"
+      - name: install Rust stable
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2021-11-20
+          components: rustfmt
+          override: true
+      - name: install Tauri dependencies (ubuntu only)
+        if: startsWith(runner.os,'Linux')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            webkit2gtk-4.0 \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
       - name: check environment
         run: |
           node -v
           npm -v
           yarn -v
+          rustc --version
+          date
       - name: install
         run: |
           cd applications/launchpad/gui-react
@@ -40,11 +49,11 @@ jobs:
         run: |
           cd applications/launchpad/gui-react
           yarn test:ci
-      - name: gui-react build
+      - name: launchpad tauri build
         run: |
-          cd applications/launchpad/gui-react
+          cd applications/launchpad
           yarn install
-          yarn build
+          yarn tauri build
       - name: Upload the test coverage
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Description
---

Build `gui-react` instead of tauri to speed up the development lifecycle.

Motivation and Context
---

`yarn tauri build` slows down the PR checking. So the PR check includes only `gui-react` build now. And the `tauri build` has been moved to the nightly job.

How Has This Been Tested?
---

See results of PR check here.
