### PR TITLE
fix: update coins list units text colour in running state

### DIFF
--- a/applications/launchpad/gui-react/src/components/CoinsList/index.tsx
+++ b/applications/launchpad/gui-react/src/components/CoinsList/index.tsx
@@ -20,7 +20,8 @@ const formatAmount = (amount: string | number) => {
 /**
  * Render the list of coins with amount.
  * @param {CoinProps[]} coins - the list of coins
- * @param {string} [color = 'inherit'] - the text color
+ * @param {string} [color = 'inherit'] - the main text color
+ * @param {string} [unitsColor] - color of units text
  * @param {boolean} [inline] - if true, renders as inline block
  * @param {boolean} [small] - if true, renders smaller font sizes
  *
@@ -33,6 +34,7 @@ const formatAmount = (amount: string | number) => {
 const CoinsList = ({
   coins,
   color,
+  unitsColor,
   showSymbols,
   inline,
   small,
@@ -62,6 +64,7 @@ const CoinsList = ({
               paddingLeft: 4,
               paddingRight: 4,
               textTransform: 'uppercase',
+              color: unitsColor,
             }}
           >
             {c.unit}

--- a/applications/launchpad/gui-react/src/components/CoinsList/styles.ts
+++ b/applications/launchpad/gui-react/src/components/CoinsList/styles.ts
@@ -22,4 +22,5 @@ export const IconWrapper = styled.span`
     width: 24px;
     height: 24px;
   }
+  color: ${({ theme }) => theme.inverted.secondary};
 `

--- a/applications/launchpad/gui-react/src/components/CoinsList/types.ts
+++ b/applications/launchpad/gui-react/src/components/CoinsList/types.ts
@@ -13,5 +13,6 @@ export interface CoinsListProps {
   inline?: boolean
   small?: boolean
   color?: string
+  unitsColor?: string
   showSymbols?: boolean
 }

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/index.tsx
@@ -281,6 +281,7 @@ const MiningBox = ({
               <CoinsList
                 coins={coins}
                 color={theme.inverted.primary}
+                unitsColor={theme.inverted.secondary}
                 showSymbols
               />
             ) : null}


### PR DESCRIPTION
Description
---
Updating icon and units text colour within `CoinsList` component.

Motivation and Context
---
#212

How Has This Been Tested?
---
Screenshots:
<img width="425" alt="Screenshot 2022-06-03 at 17 39 50" src="https://user-images.githubusercontent.com/69508715/171895972-0ceec820-aa71-4d1b-8152-a0957e4969c3.png">
<img width="425" alt="Screenshot 2022-06-03 at 17 39 32" src="https://user-images.githubusercontent.com/69508715/171896889-48cd2cf6-bb3a-4621-8512-60d00f6fa6f0.png">
<img width="425" alt="Screenshot 2022-06-03 at 17 40 15" src="https://user-images.githubusercontent.com/69508715/171897039-476d4952-871a-4566-96eb-6cf3bd18a032.png">
<img width="425" alt="Screenshot 2022-06-03 at 17 40 08" src="https://user-images.githubusercontent.com/69508715/171897160-ee26e633-969c-4ead-89a8-589d8dec94dd.png">

