### PR TITLE
chore: fix launchpad v2 nightly build name

### DIFF
--- a/.github/workflows/launchpad_v2_nightly.yml
+++ b/.github/workflows/launchpad_v2_nightly.yml
@@ -1,5 +1,5 @@
 # Runs daily
-name: Launchpad v2 NPM audit
+name: Launchpad v2 nightly build
 on:
   schedule:
     - cron: "0 1 * * *"


### PR DESCRIPTION
Description
---

Change the name of the build.

Motivation and Context
---

Two different actions (audit and nightly build) are listed with the same name:

![image](https://user-images.githubusercontent.com/11715931/172044838-86de50ab-1e98-4fba-96fe-22f9972a5c7d.png)

[https://github.com/Altalogy/tari/actions](https://github.com/Altalogy/tari/actions)


How Has This Been Tested?
---

