### PR TITLE
feat(backend): implement_launchpad_wallet_grpc_client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7056,6 +7056,7 @@ dependencies = [
  "serde_json",
  "strum 0.23.0",
  "strum_macros 0.23.1",
+ "tari_app_grpc",
  "tari_app_utilities",
  "tari_common",
  "tari_comms",
@@ -7063,6 +7064,7 @@ dependencies = [
  "tauri-build",
  "thiserror",
  "tokio 1.17.0",
+ "tonic",
  "tor-hash-passwd",
 ]
 

--- a/applications/launchpad/backend/Cargo.toml
+++ b/applications/launchpad/backend/Cargo.toml
@@ -14,8 +14,9 @@ build = "src/build.rs"
 tauri-build = { version = "1.0.0-rc.5", features = [] }
 
 [dependencies]
-tari_app_utilities = { version = "^0.32", path = "../../tari_app_utilities" }
+tari_app_utilities = {  path = "../../tari_app_utilities" }
 tari_comms = { version = "^0.32", path = "../../../comms/core" }
+tari_app_grpc = { path = "../../tari_app_grpc" }
 tari_common = { path="../../../common"}
 
 bollard = "0.11.1"
@@ -35,6 +36,8 @@ tokio = { version = "1.9", features= ["sync"] }
 futures = "0.3"
 regex= "1.5.4"
 derivative = "2.2.0"
+tonic = "0.6.2"
+
 
 [features]
 default = [ "custom-protocol" ]

--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -68,19 +68,21 @@ pub async fn wallet_events(app: AppHandle<Wry>) -> Result<(), String> {
     let app_clone = app.clone();
     tauri::async_runtime::spawn(async move {
         while let Some(response) = stream.next().await {
-            let value = response.transaction.unwrap();
-            let wt = WalletTransaction {
-                event: value.event,
-                tx_id: value.tx_id,
-                source_pk: value.source_pk,
-                dest_pk: value.dest_pk,
-                status: value.status,
-                direction: value.direction,
-                amount: value.amount,
-                message: value.message,
-            };
-            if let Err(err) = app_clone.emit_all("wallet_event", wt.clone()) {
-                warn!("Could not emit event to front-end, {:?}", err);
+            if let Some(value) = response.transaction {
+                let wt = WalletTransaction {
+                    event: value.event,
+                    tx_id: value.tx_id,
+                    source_pk: value.source_pk,
+                    dest_pk: value.dest_pk,
+                    status: value.status,
+                    direction: value.direction,
+                    amount: value.amount,
+                    message: value.message,
+                };
+                
+                if let Err(err) = app_clone.emit_all("wallet_event", wt.clone()) {
+                    warn!("Could not emit event to front-end, {:?}", err);
+                }
             }
         }
         info!("Event stream has closed.");

--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -23,12 +23,16 @@
 
 use std::{convert::TryFrom, fmt::format};
 
-use log::warn;
-use tauri::http::status;
+use config::Config;
+use futures::StreamExt;
+use log::{debug, info, warn};
+use tari_app_grpc::tari_rpc::wallet_client;
+use tauri::{http::status, AppHandle, Manager, Wry};
 
 use crate::{
-    commands::{status, DEFAULT_IMAGES},
+    commands::{status, AppState, DEFAULT_IMAGES},
     docker::{ContainerState, ImageType, TariNetwork},
+    grpc::{GrpcWalletClient, WalletTransaction},
 };
 
 pub static TARI_NETWORKS: [TariNetwork; 3] = [TariNetwork::Dibbler, TariNetwork::Igor, TariNetwork::Mainnet];
@@ -54,4 +58,32 @@ pub async fn health_check(image: &str) -> String {
         Ok(img) => status(img).await,
         Err(_err) => format!("image {} not found", image),
     }
+}
+
+#[tauri::command]
+pub async fn wallet_events(app: AppHandle<Wry>) -> Result<(), String> {
+    info!("Setting up event stream");
+    let mut wallet_client = GrpcWalletClient::new();
+    let mut stream = wallet_client.stream().await.map_err(|e| e.chained_message()).unwrap();
+    let app_clone = app.clone();
+    tauri::async_runtime::spawn(async move {
+        while let Some(response) = stream.next().await {
+            let value = response.transaction.unwrap();
+            let wt = WalletTransaction {
+                event: value.event,
+                tx_id: value.tx_id,
+                source_pk: value.source_pk,
+                dest_pk: value.dest_pk,
+                status: value.status,
+                direction: value.direction,
+                amount: value.amount,
+                message: value.message,
+            };
+            if let Err(err) = app_clone.emit_all("wallet_event", wt.clone()) {
+                warn!("Could not emit event to front-end, {:?}", err);
+            }
+        }
+        info!("Event stream has closed.");
+    });
+    Ok(())
 }

--- a/applications/launchpad/backend/src/docker/mod.rs
+++ b/applications/launchpad/backend/src/docker/mod.rs
@@ -44,8 +44,10 @@ pub use settings::{
     Sha3MinerConfig,
     WalletConfig,
     XmRigConfig,
+    BASE_NODE_GRPC_ADDRESS_URL,
     DEFAULT_MINING_ADDRESS,
     DEFAULT_MONEROD_URL,
+    WALLET_GRPC_ADDRESS_URL,
 };
 pub use workspace::{TariWorkspace, Workspaces};
 pub use wrapper::DockerWrapper;

--- a/applications/launchpad/backend/src/docker/settings.rs
+++ b/applications/launchpad/backend/src/docker/settings.rs
@@ -42,6 +42,8 @@ http://monero-stagenet.exan.tech:38081,\
 http://xmr-lux.boldsuck.org:38081,\
 http://singapore.node.xmr.pm:38081";
 
+pub const WALLET_GRPC_ADDRESS_URL: &str = "http://127.0.0.1:18143";
+pub const BASE_NODE_GRPC_ADDRESS_URL: &str = "http://127.0.0.1:18142";
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct BaseNodeConfig {
     /// The time delay before starting the container and running the base node executable

--- a/applications/launchpad/backend/src/grpc/error.rs
+++ b/applications/launchpad/backend/src/grpc/error.rs
@@ -1,0 +1,22 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GrpcError {
+    #[error("Fatal error: {0}")]
+    FatalError(String),
+    #[error("Connection error: {0}")]
+    GrpcConnection(#[from] tonic::transport::Error),
+    #[error("GRPC error: {0}")]
+    GrpcStatus(#[from] tonic::Status),
+}
+impl GrpcError {
+    pub fn chained_message(&self) -> String {
+        let mut messages = vec![self.to_string()];
+        let mut this = self as &dyn std::error::Error;
+        while let Some(next) = this.source() {
+            messages.push(next.to_string());
+            this = next;
+        }
+        messages.join(" caused by:\n")
+    }
+}

--- a/applications/launchpad/backend/src/grpc/mod.rs
+++ b/applications/launchpad/backend/src/grpc/mod.rs
@@ -1,0 +1,41 @@
+mod error;
+mod wallet_grpc_client;
+use std::convert::TryFrom;
+
+use futures::{Future, Stream};
+use serde::Serialize;
+use tari_app_grpc::tari_rpc::TransactionEvent;
+use thiserror::Error;
+pub use wallet_grpc_client::*;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WalletTransaction {
+    pub event: String,
+    pub tx_id: String,
+    pub source_pk: Vec<u8>,
+    pub dest_pk: Vec<u8>,
+    pub status: String,
+    pub direction: String,
+    pub amount: u64,
+    pub message: String,
+}
+
+impl TryFrom<TransactionEvent> for WalletTransaction {
+    type Error = String;
+
+    fn try_from(value: TransactionEvent) -> Result<Self, Self::Error> {
+        match value.event.as_str() {
+            "not_supported" => Err("event is not supported.".to_string()),
+            _ => Ok(WalletTransaction {
+                event: value.event,
+                tx_id: value.tx_id,
+                source_pk: value.source_pk,
+                dest_pk: value.dest_pk,
+                status: value.status,
+                direction: value.direction,
+                amount: value.amount,
+                message: value.message,
+            }),
+        }
+    }
+}

--- a/applications/launchpad/backend/src/grpc/wallet_grpc_client.rs
+++ b/applications/launchpad/backend/src/grpc/wallet_grpc_client.rs
@@ -1,0 +1,72 @@
+//  Copyright 2021. The Tari Project
+//
+//  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+//  following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+//  disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+//  following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote
+//  products derived from this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+//  INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+//  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+//  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+//  USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4},
+    time::Duration,
+};
+
+use bollard::container::Stats;
+use futures::{stream, Stream, StreamExt, TryStreamExt};
+use log::info;
+use tari_app_grpc::tari_rpc::{
+    wallet_client::WalletClient,
+    TransactionEvent,
+    TransactionEventRequest,
+    TransactionEventResponse,
+};
+use tonic::transport::Channel;
+
+use super::error::GrpcError;
+use crate::{
+    docker::{DockerWrapperError, LaunchpadConfig, WALLET_GRPC_ADDRESS_URL},
+    error::LauncherError,
+};
+
+type Inner = WalletClient<tonic::transport::Channel>;
+
+pub struct GrpcWalletClient {
+    inner: Option<Inner>,
+}
+
+impl GrpcWalletClient {
+    pub fn new() -> GrpcWalletClient {
+        Self { inner: None }
+    }
+
+    pub async fn connection(&mut self) -> Result<&mut Inner, GrpcError> {
+        if self.inner.is_none() {
+            let inner = Inner::connect(WALLET_GRPC_ADDRESS_URL).await?;
+            self.inner = Some(inner);
+        }
+        self.inner
+            .as_mut()
+            .ok_or_else(|| GrpcError::FatalError("no connection".into()))
+    }
+
+    pub async fn stream(&mut self) -> Result<impl Stream<Item = TransactionEventResponse>, GrpcError> {
+        let inner = self.connection().await?;
+        let request = TransactionEventRequest {};
+        let response = inner.stream_transaction_events(request).await.unwrap().into_inner();
+        Ok(response.map(|e| e.unwrap()))
+    }
+}


### PR DESCRIPTION
Description

Implement wallet grpc cleint and forward the transaction stream to the Tauri front end.
The following events should be available:
	- transaction received
	- transaction sent
	- transaction cancelled
	- transaction mined but unconfirmed

Motivation and Context
The users should be able to see all mined blocks and transactions.

How Has This Been Tested?

Manually. Async subscribe function is created and started along with Launchpad app.
Once the app is started the function tries to connect to the wallet instance and prints all received events/transactions.