### PR TITLE
feat: stream new block mined events to front-end

### DIFF
--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -592,6 +592,19 @@ impl wallet_server::Wallet for WalletGrpcServer {
                             match result {
                                 Ok(msg) => {
                                     match (*msg).clone() {
+                                        tari_wallet::transaction_service::handle::TransactionEvent::NewBlockMined(tx_id) => {
+                                            match transaction_service.get_any_transaction(tx_id).await{
+                                                Ok(found_transaction) => {
+                                                    if let Some(WalletTransaction::PendingOutbound(tx)) = found_transaction {
+                                                        let transaction_event = convert_to_transaction_event(SENT.to_string(),
+                                                            TransactionWrapper::Outbound(tx.clone()));
+                                                        send_transaction_event(transaction_event, &mut sender).await;
+                                                    } 
+                                                    
+                                                },
+                                                Err(e) => error!(target: LOG_TARGET, "Transaction service error: {}", e),
+}
+                                        }
                                         tari_wallet::transaction_service::handle::TransactionEvent::ReceivedFinalizedTransaction(tx_id) => {
                                             match transaction_service.get_completed_transaction(tx_id).await{
                                                 Ok(completed) => {
@@ -694,8 +707,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                                                 Err(e) => error!(target: LOG_TARGET, "Transaction service error: {}", e),
                                             }
                                         },
-                                        tari_wallet::transaction_service::handle::TransactionEvent::TransactionValidationStateChanged(_operation_id) => {
-
+                                        tari_wallet::transaction_service::handle::TransactionEvent::TransactionValidationStateChanged(_t_operation_id) => {
                                             let transaction_event = TransactionEvent {
                                                 event: "unknown".to_string(),
                                                 tx_id: String::default(),

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -110,7 +110,7 @@ use tonic::{Request, Response, Status};
 
 use crate::{
     grpc::{convert_to_transaction_event, TransactionWrapper},
-    notifier::{CANCELLED, CONFIRMATION, MINED, QUEUED, RECEIVED, SENT},
+    notifier::{CANCELLED, CONFIRMATION, MINED, QUEUED, RECEIVED, SENT, UNMINED},
 };
 
 const LOG_TARGET: &str = "wallet::ui::grpc";
@@ -596,7 +596,7 @@ impl wallet_server::Wallet for WalletGrpcServer {
                                             match transaction_service.get_any_transaction(tx_id).await{
                                                 Ok(found_transaction) => {
                                                     if let Some(WalletTransaction::PendingOutbound(tx)) = found_transaction {
-                                                        let transaction_event = convert_to_transaction_event(SENT.to_string(),
+                                                        let transaction_event = convert_to_transaction_event(UNMINED.to_string(),
                                                             TransactionWrapper::Outbound(tx.clone()));
                                                         send_transaction_event(transaction_event, &mut sender).await;
                                                     } 

--- a/applications/tari_console_wallet/src/notifier/mod.rs
+++ b/applications/tari_console_wallet/src/notifier/mod.rs
@@ -46,6 +46,7 @@ pub const QUEUED: &str = "queued";
 pub const CONFIRMATION: &str = "confirmation";
 pub const MINED: &str = "mined";
 pub const CANCELLED: &str = "cancelled";
+pub const NEW_BLOCK_MINED: &str = "new_block_mined";
 
 #[derive(Clone)]
 pub enum WalletEventMessage {

--- a/base_layer/wallet/src/transaction_service/handle.rs
+++ b/base_layer/wallet/src/transaction_service/handle.rs
@@ -241,6 +241,7 @@ impl Display for TransactionSendStatus {
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub enum TransactionEvent {
     MempoolBroadcastTimedOut(TxId),
+    NewBlockMined(TxId),
     ReceivedTransaction(TxId),
     ReceivedTransactionReply(TxId),
     ReceivedFinalizedTransaction(TxId),
@@ -350,6 +351,9 @@ impl fmt::Display for TransactionEvent {
             },
             TransactionEvent::TransactionValidationFailed(operation_id) => {
                 write!(f, "Transaction validation failed: {}", operation_id)
+            },
+            TransactionEvent::NewBlockMined(tx_id) => {
+                write!(f, "New block mined {}", tx_id)
             },
         }
     }

--- a/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
+++ b/base_layer/wallet/src/transaction_service/protocols/transaction_validation_protocol.rs
@@ -166,6 +166,8 @@ where
                             )
                             .await?;
                             state_changed = true;
+
+
                         } else {
                             debug!(
                                 target: LOG_TARGET,
@@ -183,7 +185,7 @@ where
                         );
                         self.update_transaction_as_unmined(unmined_tx.tx_id, &unmined_tx.status)
                             .await?;
-                        state_changed = true;
+                        self.publish_event(TransactionEvent::NewBlockMined(unmined_tx.tx_id));                            
                     }
                 }
             }


### PR DESCRIPTION
Description

Provide a new Tari event stream for:
	- new block mined event

When transaction's state is changed from Coinbase to Unmined then we have new block mined event.
Read and forward the event to the Launchpad UI.

Motivation and Context
This is an extention of ticket#155.
The launchpad users want to see the actual mining progress and all mining relalted events on the UI.
Hence we should forward the data/log streams from the underlying apps to the front-end.

How Has This Been Tested?
Not tested. It is in progress.


