### PR TITLE
feat(backend): implement wallet identity endpoint

### DIFF
--- a/applications/launchpad/backend/src/commands/service.rs
+++ b/applications/launchpad/backend/src/commands/service.rs
@@ -231,6 +231,7 @@ async fn start_service_impl(
     if !workspace.network_exists(&docker).await? {
         workspace.create_network(&docker).await?;
     }
+    //
     // Launch the container
     let image = ImageType::try_from(service_name.as_str())?;
     let container_name = workspace.start_service(image, docker.clone()).await?;

--- a/applications/launchpad/backend/src/grpc/mod.rs
+++ b/applications/launchpad/backend/src/grpc/mod.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 
 use futures::{Future, Stream};
 use serde::Serialize;
-use tari_app_grpc::tari_rpc::TransactionEvent;
+use tari_app_grpc::tari_rpc::{TransactionEvent, GetIdentityResponse};
 use thiserror::Error;
 pub use wallet_grpc_client::*;
 
@@ -18,6 +18,13 @@ pub struct WalletTransaction {
     pub direction: String,
     pub amount: u64,
     pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct WalletIdentity{
+    public_key: Vec<u8>,
+    public_address: String,
+    node_id: Vec<u8>,
 }
 
 impl TryFrom<TransactionEvent> for WalletTransaction {
@@ -36,6 +43,17 @@ impl TryFrom<TransactionEvent> for WalletTransaction {
                 amount: value.amount,
                 message: value.message,
             }),
+        }
+    }
+}
+
+impl From<GetIdentityResponse> for WalletIdentity {
+    
+    fn from(value: GetIdentityResponse) -> WalletIdentity {
+        WalletIdentity{
+            public_key: value.public_key,
+            public_address: value.public_address,
+            node_id: value.node_id,
         }
     }
 }

--- a/applications/launchpad/backend/src/grpc/wallet_grpc_client.rs
+++ b/applications/launchpad/backend/src/grpc/wallet_grpc_client.rs
@@ -32,7 +32,7 @@ use tari_app_grpc::tari_rpc::{
     wallet_client::WalletClient,
     TransactionEvent,
     TransactionEventRequest,
-    TransactionEventResponse,
+    TransactionEventResponse, GetIdentityResponse, GetIdentityRequest,
 };
 use tonic::transport::Channel;
 
@@ -68,5 +68,12 @@ impl GrpcWalletClient {
         let request = TransactionEventRequest {};
         let response = inner.stream_transaction_events(request).await.unwrap().into_inner();
         Ok(response.map(|e| e.unwrap()))
+    }
+
+    pub async fn identity(&mut self) -> Result<GetIdentityResponse, GrpcError> {
+        let inner = self.connection().await?;
+        let request = GetIdentityRequest {};
+        let identity = inner.identify(request).await?;
+        Ok(identity.into_inner())
     }
 }


### PR DESCRIPTION
Description

The wallet public key, address and connected node should be available to the user.
If the wallet container is running we may call `grpc` endpoint (identify) in order to get:
    public_key
    public_address
    node_id

Motivation and Context

User should be allowed to use his wallet or to share it.

How Has This Been Tested?

Manually: 
Started the Launchpad app.
Tor, Base Node and Wallet are started.
Wallet identity is printed.
Wallet container is stopped and error message is printed.