### PR TITLE
feat: tidy up mounts specification

### DIFF
--- a/applications/launchpad/backend/src/docker/mod.rs
+++ b/applications/launchpad/backend/src/docker/mod.rs
@@ -28,6 +28,7 @@ mod models;
 mod settings;
 mod workspace;
 mod wrapper;
+mod mounts;
 
 pub mod helpers;
 use std::{collections::HashMap, sync::RwLock};

--- a/applications/launchpad/backend/src/docker/mod.rs
+++ b/applications/launchpad/backend/src/docker/mod.rs
@@ -25,10 +25,10 @@ mod container;
 mod error;
 mod filesystem;
 mod models;
+mod mounts;
 mod settings;
 mod workspace;
 mod wrapper;
-mod mounts;
 
 pub mod helpers;
 use std::{collections::HashMap, sync::RwLock};

--- a/applications/launchpad/backend/src/docker/mounts.rs
+++ b/applications/launchpad/backend/src/docker/mounts.rs
@@ -1,0 +1,82 @@
+// Copyright 2022 The Tari Project
+// SPDX-License-Identifier: BSD-3-Clause
+
+use std::path::Path;
+use bollard::models::{Mount, MountTypeEnum};
+
+pub struct Mounts {
+    mounts: Vec<Mount>,
+}
+
+impl Mounts {
+    pub fn empty() -> Self {
+        Self { mounts: Vec::new() }
+    }
+
+    pub fn to_docker_mounts(self) -> Vec<Mount> {
+        self.mounts
+    }
+
+    pub fn with_blockchain(mut self, volume_name: String) -> Self {
+        let mount = Mount {
+            target: Some("/blockchain".to_string()),
+            source: Some(volume_name),
+            typ: Some(MountTypeEnum::VOLUME),
+            volume_options: None,
+            ..Default::default()
+        };
+        self.mounts.push(mount);
+        self
+    }
+
+    pub fn bind<P: AsRef<Path>>(mut self, source: P, target: &str) -> Self {
+        let source = canonicalize(source);
+        let mount = Mount {
+            target: Some(target.to_string()),
+            source: Some(source),
+            typ: Some(MountTypeEnum::BIND),
+            bind_options: None,
+            ..Default::default()
+        };
+        self.mounts.push(mount);
+        self
+    }
+
+    pub fn with_general<P: AsRef<Path>>(data_dir: P) -> Self {
+        Mounts::empty().bind(data_dir, "/var/tari")
+    }
+}
+
+// FIXME: This might be replaceable by std::fs::canonicalize, but I don't have a windows machine to check
+fn canonicalize<P: AsRef<Path>>(path: P) -> String {
+    #[cfg(target_os = "windows")]
+        let path =
+        format!(
+            "//{}",
+            path.as_ref()
+                .iter()
+                .filter_map(|part| {
+                    use std::{ffi::OsStr, path};
+                    use regex::Regex;
+
+                    if part == OsStr::new(&path::MAIN_SEPARATOR.to_string()) {
+                        None
+                    } else {
+                        let drive = Regex::new(r"(?P<letter>[A-Za-z]):").unwrap();
+                        let part = part.to_string_lossy().to_string();
+                        if drive.is_match(part.as_str()) {
+                            Some(drive.replace(part.as_str(), "$letter").to_lowercase())
+                        } else {
+                            Some(part)
+                        }
+                    }
+                })
+                .collect::<Vec<String>>()
+                .join("/")
+        );
+    #[cfg(target_os = "macos")]
+        let path = format!("/host_mnt{}", path.as_ref().to_string_lossy());
+    #[cfg(target_os = "linux")]
+        let path = path.as_ref().to_string_lossy().to_string();
+    path
+}

--- a/applications/launchpad/backend/src/docker/settings.rs
+++ b/applications/launchpad/backend/src/docker/settings.rs
@@ -31,6 +31,7 @@ use thiserror::Error;
 use tor_hash_passwd::EncryptedKey;
 
 use crate::docker::{models::ImageType, TariNetwork};
+use crate::docker::mounts::Mounts;
 
 // TODO get a proper mining address for each network
 pub const DEFAULT_MINING_ADDRESS: &str =
@@ -182,71 +183,22 @@ impl LaunchpadConfig {
 
     /// Similar to [`volumes`], provides a bollard configuration for mounting volumes.
     pub fn mounts(&self, image_type: ImageType, volume_name: String) -> Vec<Mount> {
-        match image_type {
-            ImageType::BaseNode => self.build_mounts(true, true, volume_name),
-            ImageType::Wallet => self.build_mounts(true, true, volume_name),
-            ImageType::XmRig => self.build_mounts(false, true, volume_name),
-            ImageType::Sha3Miner => self.build_mounts(false, true, volume_name),
-            ImageType::MmProxy => self.build_mounts(false, true, volume_name),
-            ImageType::Tor => self.build_mounts(false, false, volume_name),
-            ImageType::Monerod => self.build_mounts(false, false, volume_name),
-            ImageType::Frontail => self.build_mounts(false, true, volume_name),
-        }
+        let mounts = match image_type {
+            ImageType::BaseNode => Mounts::with_general(&self.data_directory).with_blockchain(volume_name),
+            ImageType::Wallet => Mounts::with_general(&self.data_directory).with_blockchain(volume_name),
+            ImageType::XmRig => Mounts::with_general(&self.data_directory),
+            ImageType::Sha3Miner => Mounts::with_general(&self.data_directory),
+            ImageType::MmProxy => Mounts::with_general(&self.data_directory),
+            ImageType::Tor => Mounts::empty(),
+            ImageType::Monerod => Mounts::empty(),
+            ImageType::Frontail => Mounts::with_general(&self.data_directory),
+        };
+        mounts.to_docker_mounts()
     }
 
-    fn build_mounts(&self, blockchain: bool, general: bool, volume_name: String) -> Vec<Mount> {
-        let mut mounts = Vec::with_capacity(2);
-        if general {
-            #[cfg(target_os = "windows")]
-            let host = format!(
-                "//{}",
-                self.data_directory
-                    .iter()
-                    .filter_map(|part| {
-                        use std::{ffi::OsStr, path};
 
-                        use regex::Regex;
 
-                        if part == OsStr::new(&path::MAIN_SEPARATOR.to_string()) {
-                            None
-                        } else {
-                            let drive = Regex::new(r"(?P<letter>[A-Za-z]):").unwrap();
-                            let part = part.to_string_lossy().to_string();
-                            if drive.is_match(part.as_str()) {
-                                Some(drive.replace(part.as_str(), "$letter").to_lowercase())
-                            } else {
-                                Some(part)
-                            }
-                        }
-                    })
-                    .collect::<Vec<String>>()
-                    .join("/")
-            );
-            #[cfg(target_os = "macos")]
-            let host = format!("/host_mnt{}", self.data_directory.to_string_lossy());
-            #[cfg(target_os = "linux")]
-            let host = self.data_directory.to_string_lossy().to_string();
-            let mount = Mount {
-                target: Some("/var/tari".to_string()),
-                source: Some(host),
-                typ: Some(MountTypeEnum::BIND),
-                bind_options: None,
-                ..Default::default()
-            };
-            mounts.push(mount);
-        }
-        if blockchain {
-            let mount = Mount {
-                target: Some("/blockchain".to_string()),
-                source: Some(volume_name),
-                typ: Some(MountTypeEnum::VOLUME),
-                volume_options: None,
-                ..Default::default()
-            };
-            mounts.push(mount);
-        }
-        mounts
-    }
+
 
     /// Returns a map of ports to expose to the host system. TODO - remove the hardcoding so that multiple workspaces
     /// don't have colliding exposed ports.

--- a/applications/launchpad/backend/src/docker/settings.rs
+++ b/applications/launchpad/backend/src/docker/settings.rs
@@ -30,8 +30,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tor_hash_passwd::EncryptedKey;
 
-use crate::docker::{models::ImageType, TariNetwork};
-use crate::docker::mounts::Mounts;
+use crate::docker::{models::ImageType, mounts::Mounts, TariNetwork};
 
 // TODO get a proper mining address for each network
 pub const DEFAULT_MINING_ADDRESS: &str =
@@ -195,10 +194,6 @@ impl LaunchpadConfig {
         };
         mounts.to_docker_mounts()
     }
-
-
-
-
 
     /// Returns a map of ports to expose to the host system. TODO - remove the hardcoding so that multiple workspaces
     /// don't have colliding exposed ports.


### PR DESCRIPTION
Converts the docker mounts function into a small builder pattern.
This is cleaner and gives us more flexibility for giving new containers
arbitrary mount mounts (which the grafana containers will need).

Tested manually on MacOS for regressions.

