### PR TITLE
fix: console errors about non-serializable value

### DIFF
--- a/applications/launchpad/gui-react/src/store/index.ts
+++ b/applications/launchpad/gui-react/src/store/index.ts
@@ -47,6 +47,10 @@ export const store =
       })
     : configureStore({
         reducer: persistedReducer,
+        middleware: getDefaultMiddleware => [
+          // Silent console errors about non-serializable data
+          ...getDefaultMiddleware({ serializableCheck: false }),
+        ],
         enhancers: [
           devToolsEnhancer({
             name: 'Tari Launchpad',


### PR DESCRIPTION
Description
---

Silent the console errors: `A non-serializable value was detected in the state`.

Motivation and Context
---

How Has This Been Tested?
---

**Before:**

<img width="1243" alt="image" src="https://user-images.githubusercontent.com/11715931/173809449-9020e397-430c-48de-bdfc-46e8bfd60246.png">


**After:**

Console errors do not appears.