### PR TITLE
fix: apply consistent naming for tauri events

### DIFF
--- a/applications/launchpad/backend/src/api/wallet_api.rs
+++ b/applications/launchpad/backend/src/api/wallet_api.rs
@@ -82,7 +82,7 @@ pub async fn wallet_events(app: AppHandle<Wry>) -> Result<(), String> {
                     message: value.message,
                 };
 
-                if let Err(err) = app_clone.emit_all("wallet_event", wt.clone()) {
+                if let Err(err) = app_clone.emit_all("tari://wallet_event", wt.clone()) {
                     warn!("Could not emit event to front-end, {:?}", err);
                 }
             }


### PR DESCRIPTION
The consistent naming convention should be used for tauri events.
The pattern is tari://{} or tari://{}_{}.

Motivation and Context
To avoid any confusion the naming must be consistent.

How Has This Been Tested?
It will be tested along with the front-end.
