### PR TITLE
feat: add new fields to image list

### DIFF
--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -30,8 +30,9 @@ use log::{debug, error, info, warn};
 use serde::Serialize;
 use tari_app_grpc::tari_rpc::wallet_client;
 use tauri::{http::status, AppHandle, Manager, Wry};
+
 use crate::{
-    commands::{status, AppState, DEFAULT_IMAGES, ServiceSettings},
+    commands::{status, AppState, ServiceSettings, DEFAULT_IMAGES},
     docker::{ContainerState, ImageType, TariNetwork, TariWorkspace},
     grpc::{GrpcWalletClient, WalletIdentity, WalletTransaction},
 };
@@ -68,12 +69,13 @@ pub fn network_list() -> Vec<String> {
 pub fn image_list(settings: ServiceSettings) -> Vec<ImageInfo> {
     let registry = settings.docker_registry.as_ref().map(String::as_str);
     let tag = settings.docker_tag.as_ref().map(String::as_str);
-    let images: Vec<ImageInfo> = DEFAULT_IMAGES.iter()
-        .map(|value| ImageInfo { 
-            image_name: value.image_name().to_string(), 
-            display_name: value.display_name().to_string(), 
-            docker_image: TariWorkspace::fully_qualified_image(*value, registry, tag)
-         })
+    let images: Vec<ImageInfo> = DEFAULT_IMAGES
+        .iter()
+        .map(|value| ImageInfo {
+            image_name: value.image_name().to_string(),
+            display_name: value.display_name().to_string(),
+            docker_image: TariWorkspace::fully_qualified_image(*value, registry, tag),
+        })
         .collect();
     images
 }

--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -27,12 +27,12 @@ use std::{convert::TryFrom, fmt::format};
 use config::Config;
 use futures::StreamExt;
 use log::{debug, error, info, warn};
+use serde::Serialize;
 use tari_app_grpc::tari_rpc::wallet_client;
 use tauri::{http::status, AppHandle, Manager, Wry};
-
 use crate::{
-    commands::{status, AppState, DEFAULT_IMAGES},
-    docker::{ContainerState, ImageType, TariNetwork},
+    commands::{status, AppState, DEFAULT_IMAGES, ServiceSettings},
+    docker::{ContainerState, ImageType, TariNetwork, TariWorkspace},
     grpc::{GrpcWalletClient, WalletIdentity, WalletTransaction},
 };
 
@@ -47,6 +47,13 @@ pub static TRANSACTION_EVENTS: [&str; 7] = [RECEIVED, SENT, QUEUED, CONFIRMATION
 
 pub static TARI_NETWORKS: [TariNetwork; 3] = [TariNetwork::Dibbler, TariNetwork::Igor, TariNetwork::Mainnet];
 
+#[derive(Debug, Serialize)]
+pub struct ImageInfo {
+    image_name: String,
+    display_name: String,
+    docker_image: String,
+}
+
 pub fn enum_to_list<T: Sized + ToString + Clone>(enums: &[T]) -> Vec<String> {
     enums.iter().map(|enum_value| enum_value.to_string()).collect()
 }
@@ -58,8 +65,17 @@ pub fn network_list() -> Vec<String> {
 
 /// Provide a list of image names in the Tari "ecosystem"
 #[tauri::command]
-pub fn image_list() -> Vec<String> {
-    enum_to_list::<ImageType>(&DEFAULT_IMAGES)
+pub fn image_list(settings: ServiceSettings) -> Vec<ImageInfo> {
+    let registry = settings.docker_registry.as_ref().map(String::as_str);
+    let tag = settings.docker_tag.as_ref().map(String::as_str);
+    let images: Vec<ImageInfo> = DEFAULT_IMAGES.iter()
+        .map(|value| ImageInfo { 
+            image_name: value.image_name().to_string(), 
+            display_name: value.display_name().to_string(), 
+            docker_image: TariWorkspace::fully_qualified_image(*value, registry, tag)
+         })
+        .collect();
+    images
 }
 
 pub fn event_list() -> Vec<String> {

--- a/applications/launchpad/backend/src/commands/mod.rs
+++ b/applications/launchpad/backend/src/commands/mod.rs
@@ -41,6 +41,6 @@ pub use events::events;
 pub use health_check::status;
 pub use launch_docker::launch_docker;
 pub use pull_images::{pull_images, DEFAULT_IMAGES};
-pub use service::{create_default_workspace, start_service, stop_service};
+pub use service::{create_default_workspace, start_service, stop_service, ServiceSettings};
 pub use shutdown::shutdown;
 pub use state::AppState;

--- a/applications/launchpad/backend/src/docker/models.rs
+++ b/applications/launchpad/backend/src/docker/models.rs
@@ -31,9 +31,8 @@ use bollard::{container::LogOutput, models::ContainerCreateResponse};
 use serde::{Deserialize, Serialize};
 use strum_macros::EnumIter;
 
-use crate::docker::DockerWrapperError;
-
 use super::TariWorkspace;
+use crate::docker::DockerWrapperError;
 
 //-------------------------------------------     ContainerId      ----------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/applications/launchpad/backend/src/docker/models.rs
+++ b/applications/launchpad/backend/src/docker/models.rs
@@ -33,6 +33,8 @@ use strum_macros::EnumIter;
 
 use crate::docker::DockerWrapperError;
 
+use super::TariWorkspace;
+
 //-------------------------------------------     ContainerId      ----------------------------------------------
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ContainerId(pub String);
@@ -213,6 +215,19 @@ impl ImageType {
             Self::MmProxy => "tari_mm_proxy",
             Self::Monerod => "monerod",
             Self::Frontail => "frontail",
+        }
+    }
+
+    pub fn display_name(&self) -> &str {
+        match self {
+            Self::Tor => "Tor",
+            Self::BaseNode => "Base Node",
+            Self::Wallet => "Wallet",
+            Self::XmRig => "Xmrig",
+            Self::Sha3Miner => "SHA3 miner",
+            Self::MmProxy => "MM proxy",
+            Self::Monerod => "Monerod",
+            Self::Frontail => "Frontail",
         }
     }
 


### PR DESCRIPTION
Description

We should provide more information about the docker images rather than short image name.
We should return:
```
[
  { image_name: "base_node",
    display_name: "Base Node",
    docker_image: "quay.io/tarilabs..."
  },
  {
    image_name: "sha3_miner",
    display_name: "SHA3 Miner",
    docker_image: "quay.io/tarilabs..."
  },
...
]
```
Motivation and Context
Add useful info for the launchpad's user.

How Has This Been Tested?
Shold be tested along with the front-end.