### PR TITLE
feat: add coinbase flag to identify mined transactions

### DIFF
--- a/applications/launchpad/backend/src/api/wallet_api.rs
+++ b/applications/launchpad/backend/src/api/wallet_api.rs
@@ -80,6 +80,7 @@ pub async fn wallet_events(app: AppHandle<Wry>) -> Result<(), String> {
                     direction: value.direction,
                     amount: value.amount,
                     message: value.message,
+                    is_coinbase: value.is_coinbase,
                 };
 
                 if let Err(err) = app_clone.emit_all("wallet_event", wt.clone()) {

--- a/applications/launchpad/backend/src/grpc/mod.rs
+++ b/applications/launchpad/backend/src/grpc/mod.rs
@@ -21,6 +21,7 @@ pub struct WalletTransaction {
     pub direction: String,
     pub amount: u64,
     pub message: String,
+    pub is_coinbase: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -51,6 +52,7 @@ impl TryFrom<TransactionEvent> for WalletTransaction {
                 direction: value.direction,
                 amount: value.amount,
                 message: value.message,
+                is_coinbase: value.is_coinbase,
             }),
         }
     }

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -386,6 +386,7 @@ message TransactionEvent {
     string direction = 6;
     uint64 amount = 7;
     string message = 8;
+    bool is_coinbase = 9;
 }
 
 message TransactionEventResponse {

--- a/applications/tari_console_wallet/src/grpc/mod.rs
+++ b/applications/tari_console_wallet/src/grpc/mod.rs
@@ -29,8 +29,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             status: completed.status.to_string(),
             direction: completed.direction.to_string(),
             amount: completed.amount.as_u64(),
-            message: completed.clone().message,
-            is_coinbase: (&completed.clone()).is_coinbase(),
+            message: completed.message.to_string(),
+            is_coinbase: completed.is_coinbase(),
         },
         TransactionWrapper::Outbound(outbound) => TransactionEvent {
             event,

--- a/applications/tari_console_wallet/src/grpc/mod.rs
+++ b/applications/tari_console_wallet/src/grpc/mod.rs
@@ -29,7 +29,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             status: completed.status.to_string(),
             direction: completed.direction.to_string(),
             amount: completed.amount.as_u64(),
-            message: completed.message,
+            message: completed.clone().message,
+            is_coinbase: (&completed.clone()).is_coinbase(),
         },
         TransactionWrapper::Outbound(outbound) => TransactionEvent {
             event,
@@ -40,6 +41,7 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             direction: "outbound".to_string(),
             amount: outbound.amount.as_u64(),
             message: outbound.message,
+            is_coinbase: false,
         },
         TransactionWrapper::Inbound(inbound) => TransactionEvent {
             event,
@@ -50,6 +52,7 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             direction: "inbound".to_string(),
             amount: inbound.amount.as_u64(),
             message: inbound.message,
+            is_coinbase: false,
         },
     }
 }

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1138,6 +1138,7 @@ fn simple_event(event: &str) -> TransactionEvent {
         direction: event.to_string(),
         amount: 0,
         message: String::default(),
+        is_coinbase: false,
     }
 }
 


### PR DESCRIPTION
Description

Add new field [is_coinbase] to wallet transactions to identify the mined transactions/event.
fixes: #287 

Motivation and Context
We should identify the minning transactions.

How Has This Been Tested?
Shold be tested along with the front-end.