### PR TITLE
feat: shudtodwn and destroy all containers on exit

### DIFF
--- a/applications/launchpad/backend/src/api/wallet_api.rs
+++ b/applications/launchpad/backend/src/api/wallet_api.rs
@@ -80,6 +80,7 @@ pub async fn wallet_events(app: AppHandle<Wry>) -> Result<(), String> {
                     direction: value.direction,
                     amount: value.amount,
                     message: value.message,
+                    is_coinbase: value.is_coinbase,
                 };
 
                 if let Err(err) = app_clone.emit_all("wallet_event", wt.clone()) {

--- a/applications/launchpad/backend/src/grpc/mod.rs
+++ b/applications/launchpad/backend/src/grpc/mod.rs
@@ -21,6 +21,7 @@ pub struct WalletTransaction {
     pub direction: String,
     pub amount: u64,
     pub message: String,
+    pub is_coinbase: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -51,6 +52,7 @@ impl TryFrom<TransactionEvent> for WalletTransaction {
                 direction: value.direction,
                 amount: value.amount,
                 message: value.message,
+                is_coinbase: value.is_coinbase,
             }),
         }
     }

--- a/applications/launchpad/backend/src/main.rs
+++ b/applications/launchpad/backend/src/main.rs
@@ -8,7 +8,8 @@
 #[macro_use]
 extern crate lazy_static;
 use std::{
-    thread::{self, sleep},
+    sync::{atomic::AtomicBool, Arc},
+    thread::{self, sleep, Thread},
     time::Duration,
 };
 
@@ -19,19 +20,20 @@ mod commands;
 mod docker;
 mod error;
 mod grpc;
-
-use docker::{DockerWrapper, Workspaces};
+use docker::{shutdown_all_containers, DockerWrapper, Workspaces, DOCKER_INSTANCE};
 use tauri::{
     api::cli::get_matches,
     async_runtime::block_on,
     utils::config::CliConfig,
     CustomMenuItem,
+    GlobalWindowEvent,
     Manager,
     Menu,
     MenuItem,
     PackageInfo,
     RunEvent,
     Submenu,
+    WindowEvent,
 };
 use tauri_plugin_sql::{Migration, MigrationKind, TauriSql};
 
@@ -53,7 +55,6 @@ use crate::{
 
 fn main() {
     env_logger::init();
-
     let context = tauri::generate_context!();
     let cli_config = context.config().tauri.cli.clone().unwrap();
 
@@ -122,8 +123,17 @@ fn main() {
             stop_service,
             shutdown
         ])
+        .on_window_event(on_event)
         .run(context)
         .expect("error starting");
+}
+
+fn on_event(evt: GlobalWindowEvent) {
+    if let WindowEvent::Destroyed = evt.event() {
+        info!("Stopping and destroying all tari containers");
+        thread::spawn(|| block_on(shutdown_all_containers("default".to_string(), &DOCKER_INSTANCE.clone())));
+        sleep(Duration::from_secs(5));
+    }
 }
 
 fn handle_cli_options(cli_config: &CliConfig, pkg_info: &PackageInfo) {

--- a/applications/tari_app_grpc/proto/wallet.proto
+++ b/applications/tari_app_grpc/proto/wallet.proto
@@ -386,6 +386,7 @@ message TransactionEvent {
     string direction = 6;
     uint64 amount = 7;
     string message = 8;
+    bool is_coinbase = 9;
 }
 
 message TransactionEventResponse {

--- a/applications/tari_console_wallet/src/grpc/mod.rs
+++ b/applications/tari_console_wallet/src/grpc/mod.rs
@@ -29,7 +29,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             status: completed.status.to_string(),
             direction: completed.direction.to_string(),
             amount: completed.amount.as_u64(),
-            message: completed.message,
+            message: completed.clone().message,
+            is_coinbase: (&completed.clone()).is_coinbase(),
         },
         TransactionWrapper::Outbound(outbound) => TransactionEvent {
             event,
@@ -40,6 +41,7 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             direction: "outbound".to_string(),
             amount: outbound.amount.as_u64(),
             message: outbound.message,
+            is_coinbase: false,
         },
         TransactionWrapper::Inbound(inbound) => TransactionEvent {
             event,
@@ -50,6 +52,7 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             direction: "inbound".to_string(),
             amount: inbound.amount.as_u64(),
             message: inbound.message,
+            is_coinbase: false,
         },
     }
 }

--- a/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
+++ b/applications/tari_console_wallet/src/grpc/wallet_grpc_server.rs
@@ -1138,6 +1138,7 @@ fn simple_event(event: &str) -> TransactionEvent {
         direction: event.to_string(),
         amount: 0,
         message: String::default(),
+        is_coinbase: false,
     }
 }
 


### PR DESCRIPTION

Launchpad should stop and delete all Tari containers on exit.

Motivation and Context
We should keep clean on exit.
fixes: #287 
fixes: #283 
How Has This Been Tested?
Manually. Started launchpad, then started few containers.
Clolsed the app using the `close(x)` and checked docker.
All running containers were deleted.