### PR TITLE
feat: added notification presentation and action in store

### DIFF
--- a/applications/launchpad/gui-react/src/App.tsx
+++ b/applications/launchpad/gui-react/src/App.tsx
@@ -14,6 +14,7 @@ import './styles/App.css'
 import useMiningSimulator from './useMiningSimulator'
 import useMiningScheduling from './useMiningScheduling'
 import TBotContainer from './containers/TBotContainer'
+import MiningNotifications from './containers/MiningNotifications'
 import Onboarding from './pages/onboarding'
 
 const AppContainer = styled.div`
@@ -45,6 +46,7 @@ const App = () => {
           <>
             <HomePage />
             <TBotContainer />
+            <MiningNotifications />
           </>
         )}
       </AppContainer>

--- a/applications/launchpad/gui-react/src/components/CoinsList/index.tsx
+++ b/applications/launchpad/gui-react/src/components/CoinsList/index.tsx
@@ -30,6 +30,9 @@ const formatAmount = (amount: string | number) => {
  * @param {string} unit - the unit, ie. xtr
  * @param {string} [suffixText] - the latter text after the amount and unit
  * @param {boolean} [loading] - is value being loaded
+ *
+ * @example
+ * <CoinsList coins={[{ amount: balance.value, unit: balance.currency }]} />
  */
 const CoinsList = ({
   coins,

--- a/applications/launchpad/gui-react/src/components/TBot/index.tsx
+++ b/applications/launchpad/gui-react/src/components/TBot/index.tsx
@@ -17,11 +17,18 @@ import { TBotProps, CSSShadowDefinition } from './types'
  * @prop {CSSProperties} [style] - optional TBot additional styling
  * @prop {boolean} [animate] - optional prop to trigger the new message T-Bot animation, set to true to trigger animation
  * @prop {boolean | ShadowDefinition} [shadow] - optional prop to define shadow dropped around TBot, use true for defaults (color: theme.accent, spread: 10, blur: 100)
+ * @prop {boolean} [disableEnterAnimation] - optional prop to disable enter animation
  *
  * @example
  * <TBot type='hearts' style={{ fontSize: '24px' }} animate={triggerAnimation} />
  */
-const TBot = ({ type = 'base', style, animate, shadow }: TBotProps) => {
+const TBot = ({
+  type = 'base',
+  style,
+  animate,
+  shadow,
+  disableEnterAnimation,
+}: TBotProps) => {
   const theme = useTheme()
   const { fontSize } = { fontSize: 74, ...style }
   const defaultShadow: CSSShadowDefinition = {
@@ -39,20 +46,20 @@ const TBot = ({ type = 'base', style, animate, shadow }: TBotProps) => {
     search: SvgTBotRadar,
   }
 
-  // Animation for T-Bot first render
-  const enterAnim = useSpring({
-    from: { width: '0px', height: '0px' },
-    to: {
-      width: '100%',
-      height: '100%',
-    },
-    config: {
-      duration: 100,
-    },
-  })
+  const enterAnim = disableEnterAnimation
+    ? undefined
+    : useSpring({
+        from: { width: '0px', height: '0px' },
+        to: {
+          width: '100%',
+          height: '100%',
+        },
+        config: {
+          duration: 100,
+        },
+      })
 
-  // Animation for new T-Bot messages
-  const scaleAnim = useSpring({
+  const newTBotMessageAnimation = useSpring({
     from: { transform: 'scale(1)' },
     to: {
       transform: animate ? 'scale(1.5)' : 'scale(1)',
@@ -73,7 +80,7 @@ const TBot = ({ type = 'base', style, animate, shadow }: TBotProps) => {
 
   return (
     <TBotContainer
-      style={scaleAnim}
+      style={newTBotMessageAnimation}
       shadow={shadow ? shadowDefinition : undefined}
     >
       <TBotScaleContainer style={enterAnim}>

--- a/applications/launchpad/gui-react/src/components/TBot/index.tsx
+++ b/applications/launchpad/gui-react/src/components/TBot/index.tsx
@@ -1,12 +1,14 @@
 import { useSpring } from 'react-spring'
+import { useTheme } from 'styled-components'
+
 import SvgTBotBase from '../../styles/Icons/TBotBase'
-import SvgTBotHearts from '../../styles/Icons/TBotHearts'
 import SvgTBotHeartsMonero from '../../styles/Icons/TBotHeartsMonero'
 import SvgTBotLoading from '../../styles/Icons/TBotLoading'
 import SvgTBotRadar from '../../styles/Icons/TBotSearch'
-import { TBotContainer, TBotScaleContainer } from './styles'
+import SvgTBotHearts from '../../styles/Icons/TBotHearts'
 
-import { TBotProps } from './types'
+import { TBotContainer, TBotScaleContainer, TBotShadow } from './styles'
+import { TBotProps, CSSShadowDefinition } from './types'
 
 /**
  * TBot component
@@ -14,12 +16,21 @@ import { TBotProps } from './types'
  * @prop {TBotType} [type] - TBot variant to render
  * @prop {CSSProperties} [style] - optional TBot additional styling
  * @prop {boolean} [animate] - optional prop to trigger the new message T-Bot animation, set to true to trigger animation
+ * @prop {boolean | ShadowDefinition} [shadow] - optional prop to define shadow dropped around TBot, use true for defaults (color: theme.accent, spread: 10, blur: 100)
  *
  * @example
  * <TBot type='hearts' style={{ fontSize: '24px' }} animate={triggerAnimation} />
  */
+const TBot = ({ type = 'base', style, animate, shadow }: TBotProps) => {
+  const theme = useTheme()
+  const { fontSize } = { fontSize: 74, ...style }
+  const defaultShadow: CSSShadowDefinition = {
+    color: theme.accent,
+    spread: 10,
+    blur: 100,
+    size: parseInt(fontSize.toString()),
+  }
 
-const TBot = ({ type = 'base', style, animate }: TBotProps) => {
   const botVariants = {
     base: SvgTBotBase,
     hearts: SvgTBotHearts,
@@ -55,12 +66,23 @@ const TBot = ({ type = 'base', style, animate }: TBotProps) => {
     },
   })
 
+  const shadowDefinition: CSSShadowDefinition =
+    !shadow || shadow === true ? defaultShadow : { ...defaultShadow, ...shadow }
+
   const TBotComponent = botVariants[type]
 
   return (
-    <TBotContainer style={scaleAnim}>
+    <TBotContainer
+      style={scaleAnim}
+      shadow={shadow ? shadowDefinition : undefined}
+    >
       <TBotScaleContainer style={enterAnim}>
-        <TBotComponent fontSize={74} style={style} data-testid='tbot-cmp' />
+        {shadow && <TBotShadow shadow={shadowDefinition} />}
+        <TBotComponent
+          fontSize={fontSize}
+          style={{ ...style, zIndex: 1 }}
+          data-testid='tbot-cmp'
+        />
       </TBotScaleContainer>
     </TBotContainer>
   )

--- a/applications/launchpad/gui-react/src/components/TBot/styles.ts
+++ b/applications/launchpad/gui-react/src/components/TBot/styles.ts
@@ -1,14 +1,40 @@
 import { animated } from 'react-spring'
 import styled from 'styled-components'
 
-export const TBotContainer = styled(animated.div)`
+import { CSSShadowDefinition } from './types'
+
+const SHADOW_SIZE_SCALE = 0.6
+
+export const TBotContainer = styled(animated.div)<{
+  shadow?: CSSShadowDefinition
+}>`
   display: flex;
   align-items: center;
   justify-content: center;
+  ${({ shadow }) =>
+    shadow
+      ? `margin: ${
+          (shadow.spread +
+            shadow.blur -
+            shadow.size * (1 - SHADOW_SIZE_SCALE)) /
+          2
+        }px 0;`
+      : ''}
 `
 
 export const TBotScaleContainer = styled(animated.div)`
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
+`
+
+export const TBotShadow = styled.div<{ shadow: CSSShadowDefinition }>`
+  position: absolute;
+  width: ${({ shadow }) => shadow.size * SHADOW_SIZE_SCALE}px;
+  height: ${({ shadow }) => shadow.size * SHADOW_SIZE_SCALE}px;
+  box-shadow: ${({ shadow }) =>
+    `0px 0px ${shadow.blur}px ${shadow.spread}px ${shadow.color}`};
+  border-radius: 50%;
+  z-index: 0;
 `

--- a/applications/launchpad/gui-react/src/components/TBot/types.ts
+++ b/applications/launchpad/gui-react/src/components/TBot/types.ts
@@ -1,8 +1,28 @@
 import { CSSProperties } from 'styled-components'
 export type TBotType = 'base' | 'hearts' | 'heartsMonero' | 'loading' | 'search'
 
+/**
+ * @typedef ShadowDefinition
+ * @prop {string} [color] - color of the shadow
+ * @prop {number} [spread] - box-shadow spread value
+ * @prop {number} [blur] - box-shadow blur value
+ */
+export interface ShadowDefinition {
+  color?: string
+  spread?: number
+  blur?: number
+}
+
+export interface CSSShadowDefinition {
+  color: string
+  spread: number
+  blur: number
+  size: number
+}
+
 export interface TBotProps {
   type?: TBotType
   style?: CSSProperties
   animate?: boolean
+  shadow?: boolean | ShadowDefinition
 }

--- a/applications/launchpad/gui-react/src/components/TBot/types.ts
+++ b/applications/launchpad/gui-react/src/components/TBot/types.ts
@@ -25,4 +25,5 @@ export interface TBotProps {
   style?: CSSProperties
   animate?: boolean
   shadow?: boolean | ShadowDefinition
+  disableEnterAnimation?: boolean
 }

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/validation.test.ts
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/Scheduling/ScheduleForm/validation.test.ts
@@ -1,6 +1,5 @@
 import { Interval, Schedule } from '../../../../types/general'
 import t from '../../../../locales'
-import { startOfDay } from '../../../../utils/Date'
 
 import { validate } from './validation'
 import { utcTimeToString } from './utils'

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/DelayRender.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/DelayRender.tsx
@@ -1,5 +1,12 @@
 import { useState, useEffect } from 'react'
 
+/**
+ * @name DelayRender
+ * @description component that renders elements with delay
+ *
+ * @prop {() => JSX.Element} render - render prop
+ * @prop {number} [delay] - optional delay in ms (400ms by default)
+ */
 const DelayRender = ({
   delay = 400,
   render,

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/DelayRender.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/DelayRender.tsx
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react'
+
+const DelayRender = ({
+  delay = 400,
+  render,
+}: {
+  delay?: number
+  render: () => JSX.Element
+}) => {
+  const [renderAlready, setRenderAlready] = useState(false)
+
+  useEffect(() => {
+    setRenderAlready(false)
+    const timeout = setTimeout(() => setRenderAlready(true), delay)
+
+    return () => clearTimeout(timeout)
+  }, [render])
+
+  return renderAlready ? render() : null
+}
+
+export default DelayRender

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/DelayRender.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/DelayRender.tsx
@@ -13,7 +13,10 @@ const DelayRender = ({
     setRenderAlready(false)
     const timeout = setTimeout(() => setRenderAlready(true), delay)
 
-    return () => clearTimeout(timeout)
+    return () => {
+      setRenderAlready(false)
+      clearTimeout(timeout)
+    }
   }, [render])
 
   return renderAlready ? render() : null

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariNotificationComponent.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariNotificationComponent.tsx
@@ -1,5 +1,6 @@
 import { useTheme } from 'styled-components'
 
+import { BlockMinedNotification } from '../../../store/mining/types'
 import Modal from '../../../components/Modal'
 import Text from '../../../components/Text'
 import Button from '../../../components/Button'
@@ -8,20 +9,19 @@ import CoinsList from '../../../components/CoinsList'
 
 import { ContentWrapper, MessageWrapper } from './styles'
 
-// eslint-disable-next-line quotes
-const whatHaveYouJustDone = `You've just mined a Tari block!`
-
-const TariNotificationContainer = ({
-  amount,
+const TariNotificationComponent = ({
+  notification,
+  open,
   onClose,
 }: {
-  amount: number
+  notification: BlockMinedNotification
+  open: boolean
   onClose: () => void
 }) => {
   const theme = useTheme()
 
   return (
-    <Modal open onClose={onClose} size='small'>
+    <Modal open={open} onClose={onClose} size='small'>
       <ContentWrapper>
         <MessageWrapper>
           <div>
@@ -35,12 +35,14 @@ const TariNotificationContainer = ({
               tastic
             </Text>
           </div>
-          <Text type='subheader'>{whatHaveYouJustDone}</Text>
+          <Text type='subheader'>{notification.header}</Text>
           <TBot type='hearts' shadow animate={false} />
-          <Text style={{ textAlign: 'center' }}>
-            Congratarilations! A new Tari block has been mined!
-          </Text>
-          <CoinsList coins={[{ amount, unit: 'xtr' }]} />
+          <Text style={{ textAlign: 'center' }}>{notification.message}</Text>
+          <CoinsList
+            coins={[
+              { amount: notification.amount, unit: notification.currency },
+            ]}
+          />
           <Text>has been added to your wallet.</Text>
         </MessageWrapper>
         <Button
@@ -54,4 +56,4 @@ const TariNotificationContainer = ({
   )
 }
 
-export default TariNotificationContainer
+export default TariNotificationComponent

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariNotificationComponent.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariNotificationComponent.tsx
@@ -36,7 +36,7 @@ const TariNotificationContainer = ({
             </Text>
           </div>
           <Text type='subheader'>{whatHaveYouJustDone}</Text>
-          <TBot type='hearts' shadow />
+          <TBot type='hearts' shadow animate={false} />
           <Text style={{ textAlign: 'center' }}>
             Congratarilations! A new Tari block has been mined!
           </Text>

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariNotificationComponent.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariNotificationComponent.tsx
@@ -1,0 +1,57 @@
+import { useTheme } from 'styled-components'
+
+import Modal from '../../../components/Modal'
+import Text from '../../../components/Text'
+import Button from '../../../components/Button'
+import TBot from '../../../components/TBot'
+import CoinsList from '../../../components/CoinsList'
+
+import { ContentWrapper, MessageWrapper } from './styles'
+
+// eslint-disable-next-line quotes
+const whatHaveYouJustDone = `You've just mined a Tari block!`
+
+const TariNotificationContainer = ({
+  amount,
+  onClose,
+}: {
+  amount: number
+  onClose: () => void
+}) => {
+  const theme = useTheme()
+
+  return (
+    <Modal open onClose={onClose} size='small'>
+      <ContentWrapper>
+        <MessageWrapper>
+          <div>
+            <Text as='span' type='subheader'>
+              Fan
+            </Text>
+            <Text as='span' type='subheader' color={theme.accent}>
+              tari
+            </Text>
+            <Text as='span' type='subheader'>
+              tastic
+            </Text>
+          </div>
+          <Text type='subheader'>{whatHaveYouJustDone}</Text>
+          <TBot type='hearts' shadow />
+          <Text style={{ textAlign: 'center' }}>
+            Congratarilations! A new Tari block has been mined!
+          </Text>
+          <CoinsList coins={[{ amount, unit: 'xtr' }]} />
+          <Text>has been added to your wallet.</Text>
+        </MessageWrapper>
+        <Button
+          style={{ width: '100%', justifyContent: 'center' }}
+          onClick={onClose}
+        >
+          Got it
+        </Button>
+      </ContentWrapper>
+    </Modal>
+  )
+}
+
+export default TariNotificationContainer

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariNotificationComponent.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariNotificationComponent.tsx
@@ -1,12 +1,12 @@
-import { useTheme } from 'styled-components'
-
 import { BlockMinedNotification } from '../../../store/mining/types'
 import Modal from '../../../components/Modal'
 import Text from '../../../components/Text'
 import Button from '../../../components/Button'
 import TBot from '../../../components/TBot'
 import CoinsList from '../../../components/CoinsList'
+import t from '../../../locales'
 
+import TariText from './TariText'
 import { ContentWrapper, MessageWrapper } from './styles'
 
 const TariNotificationComponent = ({
@@ -18,38 +18,27 @@ const TariNotificationComponent = ({
   open: boolean
   onClose: () => void
 }) => {
-  const theme = useTheme()
-
   return (
     <Modal open={open} onClose={onClose} size='small'>
       <ContentWrapper>
         <MessageWrapper>
-          <div>
-            <Text as='span' type='subheader'>
-              Fan
-            </Text>
-            <Text as='span' type='subheader' color={theme.accent}>
-              tari
-            </Text>
-            <Text as='span' type='subheader'>
-              tastic
-            </Text>
-          </div>
-          <Text type='subheader'>{notification.header}</Text>
-          <TBot type='hearts' shadow animate={false} />
-          <Text style={{ textAlign: 'center' }}>{notification.message}</Text>
+          <TariText>{notification.header}</TariText>
+          <TBot type='hearts' shadow disableEnterAnimation />
+          <TariText style={{ textAlign: 'center' }} type='defaultMedium'>
+            {notification.message}
+          </TariText>
           <CoinsList
             coins={[
               { amount: notification.amount, unit: notification.currency },
             ]}
           />
-          <Text>has been added to your wallet.</Text>
+          <Text>{t.mining.notification.added}</Text>
         </MessageWrapper>
         <Button
           style={{ width: '100%', justifyContent: 'center' }}
           onClick={onClose}
         >
-          Got it
+          {t.mining.notification.ack}
         </Button>
       </ContentWrapper>
     </Modal>

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariNotificationComponent.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariNotificationComponent.tsx
@@ -9,6 +9,14 @@ import t from '../../../locales'
 import TariText from './TariText'
 import { ContentWrapper, MessageWrapper } from './styles'
 
+/**
+ * @name TariNotificationComponent
+ * @description component that shows modal notification about new Tari block mined
+ *
+ * @prop {BlockMinedNotification} notification - notification to show
+ * @prop {boolean} open - whether modal should be open
+ * @prop {() => void} onClose - callback to call when user acknowledges the notification
+ */
 const TariNotificationComponent = ({
   notification,
   open,
@@ -22,7 +30,9 @@ const TariNotificationComponent = ({
     <Modal open={open} onClose={onClose} size='small'>
       <ContentWrapper>
         <MessageWrapper>
-          <TariText>{notification.header}</TariText>
+          <TariText style={{ textAlign: 'center' }}>
+            {notification.header}
+          </TariText>
           <TBot type='hearts' shadow disableEnterAnimation />
           <TariText style={{ textAlign: 'center' }} type='defaultMedium'>
             {notification.message}

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariText.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariText.tsx
@@ -4,6 +4,14 @@ import { useTheme } from 'styled-components'
 import Text from '../../../components/Text'
 import { TextType } from '../../../components/Text/types'
 
+/**
+ * @name TariText
+ * @description Text component that renders text with all `tari` and `Tari` instances in accent colour
+ *
+ * @prop {string} children - text to render with accent
+ * @prop {CSSProperties} [style] - optional override for main text container
+ * @prop {TextType} [type] - type of Text to render
+ */
 const TariText = ({
   children,
   style,
@@ -15,28 +23,20 @@ const TariText = ({
 }) => {
   const theme = useTheme()
 
-  const parts = children.split('tari')
-  const textElements = parts.flatMap((textPart, index) =>
-    index === parts.length - 1
-      ? [
-          <Text key={textPart} as='span' type={type}>
-            {textPart}
-          </Text>,
-        ]
-      : [
-          <Text key={textPart} as='span' type={type}>
-            {textPart}
-          </Text>,
-          <Text
-            key={`tari-${index}`}
-            as='span'
-            type={type}
-            color={theme.accent}
-          >
-            tari
-          </Text>,
-        ],
-  )
+  const parts = children
+    .replaceAll('tari', '_tari_')
+    .replaceAll('Tari', '_Tari_')
+    .split('_')
+  const textElements = parts.map((part, index) => (
+    <Text
+      key={`${part}-${index}`}
+      as='span'
+      color={part.toLowerCase() === 'tari' ? theme.accent : undefined}
+      type={type}
+    >
+      {part}
+    </Text>
+  ))
 
   return <span style={style}>{textElements}</span>
 }

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariText.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/TariText.tsx
@@ -1,0 +1,44 @@
+import { CSSProperties } from 'react'
+import { useTheme } from 'styled-components'
+
+import Text from '../../../components/Text'
+import { TextType } from '../../../components/Text/types'
+
+const TariText = ({
+  children,
+  style,
+  type = 'subheader',
+}: {
+  children: string
+  style?: CSSProperties
+  type?: TextType
+}) => {
+  const theme = useTheme()
+
+  const parts = children.split('tari')
+  const textElements = parts.flatMap((textPart, index) =>
+    index === parts.length - 1
+      ? [
+          <Text key={textPart} as='span' type={type}>
+            {textPart}
+          </Text>,
+        ]
+      : [
+          <Text key={textPart} as='span' type={type}>
+            {textPart}
+          </Text>,
+          <Text
+            key={`tari-${index}`}
+            as='span'
+            type={type}
+            color={theme.accent}
+          >
+            tari
+          </Text>,
+        ],
+  )
+
+  return <span style={style}>{textElements}</span>
+}
+
+export default TariText

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import { useAppSelector, useAppDispatch } from '../../../store/hooks'
 import { actions } from '../../../store/mining'
 import { selectNotifications } from '../../../store/mining/selectors'
@@ -8,8 +9,16 @@ import DelayRender from './DelayRender'
 const TariNotificationContainer = () => {
   const [notification] = useAppSelector(selectNotifications)
   const dispatch = useAppDispatch()
-  const onClose = () => dispatch(actions.acknowledgeNotification())
-  const populate = () => dispatch(actions.addDummyNotification())
+  const [open, setOpen] = useState(true)
+  const onClose = () => {
+    setOpen(false)
+    dispatch(actions.acknowledgeNotification())
+  }
+  useEffect(() => setOpen(true), [notification])
+  const populate = () => {
+    dispatch(actions.addNotification({ amount: 1232, currency: 'xtr' }))
+    dispatch(actions.addNotification({ amount: 2344, currency: 'xtr' }))
+  }
 
   return (
     <>
@@ -17,7 +26,11 @@ const TariNotificationContainer = () => {
       {notification ? (
         <DelayRender
           render={() => (
-            <TariNotification amount={notification.amount} onClose={onClose} />
+            <TariNotification
+              open={open}
+              notification={notification}
+              onClose={onClose}
+            />
           )}
         />
       ) : null}

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
@@ -6,6 +6,11 @@ import { selectNotifications } from '../../../store/mining/selectors'
 import TariNotification from './TariNotificationComponent'
 import DelayRender from './DelayRender'
 
+/**
+ * @name TariNotificationContainer
+ * @description container that connects tari notification to tari-specific notifications of mined blocks
+ * it takes care to render each notification in the list after a delay
+ */
 const TariNotificationContainer = () => {
   const [notification] = useAppSelector(selectNotifications)
   const dispatch = useAppDispatch()

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
@@ -15,31 +15,18 @@ const TariNotificationContainer = () => {
     dispatch(actions.acknowledgeNotification())
   }
   useEffect(() => setOpen(true), [notification])
-  const populate = () => {
-    dispatch(
-      actions.notifyUserAboutMinedTariBlock({ amount: 1232, currency: 'xtr' }),
-    )
-    dispatch(
-      actions.notifyUserAboutMinedTariBlock({ amount: 2344, currency: 'xtr' }),
-    )
-  }
 
-  return (
-    <>
-      <button onClick={populate}>test</button>
-      {notification ? (
-        <DelayRender
-          render={() => (
-            <TariNotification
-              open={open}
-              notification={notification}
-              onClose={onClose}
-            />
-          )}
+  return notification ? (
+    <DelayRender
+      render={() => (
+        <TariNotification
+          open={open}
+          notification={notification}
+          onClose={onClose}
         />
-      ) : null}
-    </>
-  )
+      )}
+    />
+  ) : null
 }
 
 export default TariNotificationContainer

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
@@ -16,8 +16,12 @@ const TariNotificationContainer = () => {
   }
   useEffect(() => setOpen(true), [notification])
   const populate = () => {
-    dispatch(actions.addNotification({ amount: 1232, currency: 'xtr' }))
-    dispatch(actions.addNotification({ amount: 2344, currency: 'xtr' }))
+    dispatch(
+      actions.notifyUserAboutMinedTariBlock({ amount: 1232, currency: 'xtr' }),
+    )
+    dispatch(
+      actions.notifyUserAboutMinedTariBlock({ amount: 2344, currency: 'xtr' }),
+    )
   }
 
   return (

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
@@ -1,0 +1,13 @@
+import { useState } from 'react'
+
+import TariNotification from './TariNotificationComponent'
+
+const TariNotificationContainer = () => {
+  const [open, setOpen] = useState(true)
+  const amount = 999
+  const onClose = () => setOpen(false)
+
+  return open ? <TariNotification amount={amount} onClose={onClose} /> : null
+}
+
+export default TariNotificationContainer

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/index.tsx
@@ -1,13 +1,28 @@
-import { useState } from 'react'
+import { useAppSelector, useAppDispatch } from '../../../store/hooks'
+import { actions } from '../../../store/mining'
+import { selectNotifications } from '../../../store/mining/selectors'
 
 import TariNotification from './TariNotificationComponent'
+import DelayRender from './DelayRender'
 
 const TariNotificationContainer = () => {
-  const [open, setOpen] = useState(true)
-  const amount = 999
-  const onClose = () => setOpen(false)
+  const [notification] = useAppSelector(selectNotifications)
+  const dispatch = useAppDispatch()
+  const onClose = () => dispatch(actions.acknowledgeNotification())
+  const populate = () => dispatch(actions.addDummyNotification())
 
-  return open ? <TariNotification amount={amount} onClose={onClose} /> : null
+  return (
+    <>
+      <button onClick={populate}>test</button>
+      {notification ? (
+        <DelayRender
+          render={() => (
+            <TariNotification amount={notification.amount} onClose={onClose} />
+          )}
+        />
+      ) : null}
+    </>
+  )
 }
 
 export default TariNotificationContainer

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/styles.ts
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/styles.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components'
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  height: 100%;
+  padding: ${({ theme }) => theme.spacing(2)};
+  padding-top: 0;
+  box-sizing: border-box;
+`
+
+export const MessageWrapper = styled.div`
+  display: flex;
+  flex-grow: 1;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/styles.ts
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/TariNotification/styles.ts
@@ -17,4 +17,5 @@ export const MessageWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  row-gap: ${({ theme }) => theme.spacing(0.5)};
 `

--- a/applications/launchpad/gui-react/src/containers/MiningNotifications/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningNotifications/index.tsx
@@ -1,0 +1,5 @@
+import TariNotification from './TariNotification'
+
+const MiningNotifications = TariNotification
+
+export default MiningNotifications

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings.test.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings.test.tsx
@@ -16,6 +16,7 @@ describe('MiningSettings', () => {
       reducer: rootReducer,
       preloadedState: {
         mining: {
+          notifications: [],
           tari: {},
           merged: {
             address: 'initial-address-value',

--- a/applications/launchpad/gui-react/src/locales/mining.ts
+++ b/applications/launchpad/gui-react/src/locales/mining.ts
@@ -78,6 +78,19 @@ const translations = {
     wrongUrlFormat: 'Oops! This is not a valid URL',
     moneroUrlPlaceholder: 'Set URL address',
   },
+  notification: {
+    // eslint-disable-next-line quotes
+    youHaveOnlyGoneAndDoneIt: ` You've just mined a Tari block!`,
+    headers: [
+      'Fantaritastic!',
+      'Congratulations, brave Miner!',
+      'Holly moly, what a success!',
+    ],
+    messages: [
+      'Congratarilations! A new Tari block has been mined!',
+      'You did it, Miner! A new Tari block has been mined!',
+    ],
+  },
 }
 
 export default translations

--- a/applications/launchpad/gui-react/src/locales/mining.ts
+++ b/applications/launchpad/gui-react/src/locales/mining.ts
@@ -79,14 +79,18 @@ const translations = {
     moneroUrlPlaceholder: 'Set URL address',
   },
   notification: {
-    // eslint-disable-next-line quotes
-    youHaveOnlyGoneAndDoneIt: ` You've just mined a Tari block!`,
     added: 'has been added to your wallet.',
     ack: 'Got it',
+    // WARNING do not use '_' in headers and messages (see TariText.tsx)
     headers: [
-      'Fantaritastic!',
-      'Congratulations, brave Miner!',
-      'Holly moly, what a success!',
+      // eslint-disable-next-line quotes
+      `Fantaritastic! You've just mined a Tari block!`,
+      // eslint-disable-next-line quotes
+      `Congratulations, brave Miner! You've just mined a Tari block!`,
+      // eslint-disable-next-line quotes
+      `Holly moly, what a success! You've just mined a Tari block!`,
+      'Holy moly, you mine Tari like a boss!',
+      'Miner, have you taken lessons from the Dwarves of Moria?',
     ],
     messages: [
       'Congratarilations! A new Tari block has been mined!',

--- a/applications/launchpad/gui-react/src/locales/mining.ts
+++ b/applications/launchpad/gui-react/src/locales/mining.ts
@@ -81,6 +81,8 @@ const translations = {
   notification: {
     // eslint-disable-next-line quotes
     youHaveOnlyGoneAndDoneIt: ` You've just mined a Tari block!`,
+    added: 'has been added to your wallet.',
+    ack: 'Got it',
     headers: [
       'Fantaritastic!',
       'Congratulations, brave Miner!',

--- a/applications/launchpad/gui-react/src/store/mining/index.test.ts
+++ b/applications/launchpad/gui-react/src/store/mining/index.test.ts
@@ -6,6 +6,7 @@ describe('Mining Redux slice', () => {
     // given
     const testAddress = 'testAddress'
     const state: MiningState = {
+      notifications: [],
       tari: {},
       merged: {
         address: undefined,
@@ -13,6 +14,7 @@ describe('Mining Redux slice', () => {
       },
     }
     const expected: MiningState = {
+      notifications: [],
       tari: {},
       merged: {
         address: testAddress,
@@ -37,6 +39,7 @@ describe('Mining Redux slice', () => {
     const testUrls = [{ url: 'some-url-1' }, { url: 'some-url-2' }]
 
     const state: MiningState = {
+      notifications: [],
       tari: {},
       merged: {
         address: undefined,
@@ -46,6 +49,7 @@ describe('Mining Redux slice', () => {
     }
     const expected: MiningState = {
       tari: {},
+      notifications: [],
       merged: {
         address: testAddress,
         threads: testThreads,

--- a/applications/launchpad/gui-react/src/store/mining/index.ts
+++ b/applications/launchpad/gui-react/src/store/mining/index.ts
@@ -1,9 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { v4 as uuidv4 } from 'uuid'
 
-import { MiningNodeType, ScheduleId, CoinType } from '../../types/general'
+import { MiningNodeType, ScheduleId } from '../../types/general'
 import MiningConfig from '../../config/mining'
-import t from '../../locales'
 
 import {
   startMiningNode,

--- a/applications/launchpad/gui-react/src/store/mining/index.ts
+++ b/applications/launchpad/gui-react/src/store/mining/index.ts
@@ -21,6 +21,7 @@ export const initialState: MiningState = {
     urls: MiningConfig.defaultMoneroUrls.map(url => ({ url })),
     session: undefined,
   },
+  notifications: [{ amount: 777, currency: 'xtr' }],
 }
 
 const miningSlice = createSlice({
@@ -95,6 +96,20 @@ const miningSlice = createSlice({
       }>,
     ) {
       state.merged = { ...state.merged, ...action.payload }
+    },
+    acknowledgeNotification(state) {
+      const [_head, ...notificationsLeft] = state.notifications
+      state.notifications = notificationsLeft
+    },
+    addDummyNotification(state) {
+      state.notifications = [
+        ...state.notifications,
+        {
+          amount: 123,
+          currency: 'xtr',
+        },
+        { amount: 324, currency: 'xtr' },
+      ]
     },
   },
 })

--- a/applications/launchpad/gui-react/src/store/mining/index.ts
+++ b/applications/launchpad/gui-react/src/store/mining/index.ts
@@ -5,7 +5,11 @@ import { MiningNodeType, ScheduleId, CoinType } from '../../types/general'
 import MiningConfig from '../../config/mining'
 import t from '../../locales'
 
-import { startMiningNode, stopMiningNode } from './thunks'
+import {
+  startMiningNode,
+  stopMiningNode,
+  notifyUserAboutMinedTariBlock,
+} from './thunks'
 import { MiningState, MiningActionReason, MoneroUrl } from './types'
 
 const currencies: Record<MiningNodeType, string[]> = {
@@ -103,24 +107,19 @@ const miningSlice = createSlice({
       const [_head, ...notificationsLeft] = state.notifications
       state.notifications = notificationsLeft
     },
-    addNotification(
-      state,
-      action: PayloadAction<{ amount: number; currency: CoinType }>,
-    ) {
-      const newNotification = {
-        ...action.payload,
-        message:
-          t.mining.notification.messages[
-            Math.floor(Math.random() * t.mining.notification.messages.length)
-          ],
-        header:
-          t.mining.notification.headers[
-            Math.floor(Math.random() * t.mining.notification.headers.length)
-          ],
-      }
+  },
+  extraReducers: builder => {
+    builder.addCase(
+      notifyUserAboutMinedTariBlock.fulfilled,
+      (state, action) => {
+        const newNotification = {
+          ...action.meta.arg,
+          ...action.payload,
+        }
 
-      state.notifications = [...state.notifications, newNotification]
-    },
+        state.notifications = [...state.notifications, newNotification]
+      },
+    )
   },
 })
 
@@ -130,6 +129,7 @@ export const actions = {
   ...miningActions,
   startMiningNode,
   stopMiningNode,
+  notifyUserAboutMinedTariBlock,
 }
 
 export default miningSlice.reducer

--- a/applications/launchpad/gui-react/src/store/mining/index.ts
+++ b/applications/launchpad/gui-react/src/store/mining/index.ts
@@ -1,7 +1,9 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { v4 as uuidv4 } from 'uuid'
-import { MiningNodeType, ScheduleId } from '../../types/general'
+
+import { MiningNodeType, ScheduleId, CoinType } from '../../types/general'
 import MiningConfig from '../../config/mining'
+import t from '../../locales'
 
 import { startMiningNode, stopMiningNode } from './thunks'
 import { MiningState, MiningActionReason, MoneroUrl } from './types'
@@ -21,7 +23,7 @@ export const initialState: MiningState = {
     urls: MiningConfig.defaultMoneroUrls.map(url => ({ url })),
     session: undefined,
   },
-  notifications: [{ amount: 777, currency: 'xtr' }],
+  notifications: [],
 }
 
 const miningSlice = createSlice({
@@ -101,15 +103,23 @@ const miningSlice = createSlice({
       const [_head, ...notificationsLeft] = state.notifications
       state.notifications = notificationsLeft
     },
-    addDummyNotification(state) {
-      state.notifications = [
-        ...state.notifications,
-        {
-          amount: 123,
-          currency: 'xtr',
-        },
-        { amount: 324, currency: 'xtr' },
-      ]
+    addNotification(
+      state,
+      action: PayloadAction<{ amount: number; currency: CoinType }>,
+    ) {
+      const newNotification = {
+        ...action.payload,
+        message:
+          t.mining.notification.messages[
+            Math.floor(Math.random() * t.mining.notification.messages.length)
+          ],
+        header:
+          t.mining.notification.headers[
+            Math.floor(Math.random() * t.mining.notification.headers.length)
+          ],
+      }
+
+      state.notifications = [...state.notifications, newNotification]
     },
   },
 })

--- a/applications/launchpad/gui-react/src/store/mining/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/mining/selectors.ts
@@ -9,6 +9,9 @@ import {
   TariMiningSetupRequired,
 } from './types'
 
+export const selectNotifications = (r: RootState) =>
+  r.mining.notifications || []
+
 /**
  * ============== TARI ===================
  */

--- a/applications/launchpad/gui-react/src/store/mining/types.ts
+++ b/applications/launchpad/gui-react/src/store/mining/types.ts
@@ -55,6 +55,14 @@ export interface MergedMiningNodeState extends MiningNodeState {
   urls?: MoneroUrl[]
 }
 
+/**
+ * @typedef BlockMinedNotification
+ *
+ * @prop {number} amount - amount mined
+ * @prop {CoinType} currency - what currency was awarded for mining
+ * @prop {string} header - header message for notification
+ * @prop {string} message - additional body message for notification
+ */
 export interface BlockMinedNotification {
   amount: number
   header: string

--- a/applications/launchpad/gui-react/src/store/mining/types.ts
+++ b/applications/launchpad/gui-react/src/store/mining/types.ts
@@ -57,6 +57,8 @@ export interface MergedMiningNodeState extends MiningNodeState {
 
 export interface BlockMinedNotification {
   amount: number
+  header: string
+  message: string
   currency: CoinType
 }
 

--- a/applications/launchpad/gui-react/src/store/mining/types.ts
+++ b/applications/launchpad/gui-react/src/store/mining/types.ts
@@ -1,4 +1,4 @@
-import { ScheduleId } from '../../types/general'
+import { ScheduleId, CoinType } from '../../types/general'
 import {
   ContainerStateFields,
   Container,
@@ -55,9 +55,15 @@ export interface MergedMiningNodeState extends MiningNodeState {
   urls?: MoneroUrl[]
 }
 
+export interface BlockMinedNotification {
+  amount: number
+  currency: CoinType
+}
+
 export interface MiningState {
   tari: MiningNodeState
   merged: MergedMiningNodeState
+  notifications: BlockMinedNotification[]
 }
 
 export interface MiningContainersState extends ContainerStateFields {

--- a/applications/launchpad/gui-react/src/styles/Icons/TBotHearts.tsx
+++ b/applications/launchpad/gui-react/src/styles/Icons/TBotHearts.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { SVGProps } from 'react'
 
 const SvgTBotHearts = (props: SVGProps<SVGSVGElement>) => (
@@ -6,7 +5,7 @@ const SvgTBotHearts = (props: SVGProps<SVGSVGElement>) => (
     width='1em'
     height='1em'
     viewBox='0 0 1419 1420'
-    fill='none'
+    fill='transparent'
     xmlns='http://www.w3.org/2000/svg'
     data-testid='svg-tbothearts'
     {...props}


### PR DESCRIPTION
Description
---

- [x] showing stack of tari mined block notifications
- [x] tari mined block notification triggers OS notification with the same random text
- [x] when accepting multiple notifications, each notification is delayed
- [x] update message arrays to include new copy
- [ ] add notification after correct event - other PR, after #188

Motivation and Context
---

#15

How Has This Been Tested?
---

![image](https://user-images.githubusercontent.com/9142942/174560933-0ae3c793-16b3-4685-9266-8aafed5d4888.png)

(the 'test' button wast here only for testing purposes'
![tari-notif-stack](https://user-images.githubusercontent.com/9142942/174561119-ab37697b-5603-43bc-817d-71bcf07f4380.gif)
