### PR TITLE
feat: monero address validation

### DIFF
--- a/applications/launchpad/backend/src/docker/models.rs
+++ b/applications/launchpad/backend/src/docker/models.rs
@@ -230,7 +230,9 @@ impl ImageType {
             Self::Sha3Miner => "SHA3 miner",
             Self::MmProxy => "MM proxy",
             Self::Monerod => "Monerod",
-            Self::Frontail => "Frontail",
+            Self::Loki => "Loki",
+            Self::Promtail => "Promtail",
+            Self::Grafana => "Grafana",
         }
     }
 

--- a/applications/launchpad/gui-react/src/components/Inputs/Input/index.tsx
+++ b/applications/launchpad/gui-react/src/components/Inputs/Input/index.tsx
@@ -30,6 +30,8 @@ import { useTheme } from 'styled-components'
  * @prop {CSSProperties} [style] - styles for actual input element
  * @prop {CSSProperties} [containerStyle] - styles for input container
  * @prop {boolean} [inverted] - use inverted styling
+ * @prop {boolean} [withError=true] - does the input uses the error props? 'true' value will preserve
+ *        the bottom spacing so the layout will not flicker when error message appears and disappears.
  */
 
 const Input = (
@@ -50,6 +52,7 @@ const Input = (
     style,
     containerStyle,
     inverted,
+    withError = true,
   }: InputProps,
   ref?: React.ForwardedRef<HTMLInputElement>,
 ) => {
@@ -77,7 +80,12 @@ const Input = (
           {label}
         </Label>
       )}
-      <InputContainer disabled={disabled} style={containerStyle}>
+      <InputContainer
+        disabled={disabled}
+        $error={Boolean(error)}
+        $withError={withError}
+        style={containerStyle}
+      >
         <StyledInput
           id={id}
           autoFocus={autoFocus}

--- a/applications/launchpad/gui-react/src/components/Inputs/Input/styles.ts
+++ b/applications/launchpad/gui-react/src/components/Inputs/Input/styles.ts
@@ -33,7 +33,11 @@ export const StyledInput = styled.input<InputHTMLAttributes<HTMLInputElement>>`
   }
 `
 
-export const InputContainer = styled.div<{ disabled?: boolean }>`
+export const InputContainer = styled.div<{
+  disabled?: boolean
+  $error: boolean
+  $withError: boolean
+}>`
   height: 42px;
   width: 369px;
   line-height: 42px;
@@ -45,6 +49,8 @@ export const InputContainer = styled.div<{ disabled?: boolean }>`
   border-color: ${({ theme }) => theme.borderColor};
   border-radius: 8px;
   font-family: 'AvenirMedium';
+  margin-bottom: ${({ $withError, $error, theme }) =>
+    $error || !$withError ? '0' : theme.spacingVertical(1.6)};
   :focus-within {
     outline: none;
     border-color: ${({ theme }) => theme.accent};

--- a/applications/launchpad/gui-react/src/components/Inputs/Input/types.ts
+++ b/applications/launchpad/gui-react/src/components/Inputs/Input/types.ts
@@ -17,4 +17,5 @@ export interface InputProps
   style?: CSSProperties
   containerStyle?: CSSProperties
   inverted?: boolean
+  withError?: boolean
 }

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/SetupMergedWithForm.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBoxMerged/SetupMergedWithForm.tsx
@@ -69,12 +69,19 @@ const SetupMergedWithForm = ({
               name='address'
               control={control}
               defaultValue=''
-              rules={{ required: true, minLength: 1 }}
+              rules={{
+                required: true,
+                minLength: {
+                  value: 12,
+                  message: t.mining.settings.moneroAddressError,
+                },
+              }}
               render={({ field }) => (
                 <Input
                   placeholder={t.mining.setup.addressPlaceholder}
                   testId='address-input'
                   autoFocus
+                  error={formState.errors.address?.message}
                   {...field}
                 />
               )}

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings/MiningSettings.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings/MiningSettings.tsx
@@ -1,4 +1,9 @@
-import { Controller, Control, UseFormSetValue } from 'react-hook-form'
+import {
+  Controller,
+  Control,
+  UseFormSetValue,
+  FormState,
+} from 'react-hook-form'
 import { useTheme } from 'styled-components'
 import Button from '../../../components/Button'
 import IconButton from '../../../components/IconButton'
@@ -26,11 +31,13 @@ const isAuthenticationApplied = (values: SettingsInputs): boolean => {
 }
 
 const MiningSettings = ({
+  formState,
   control,
   values,
   setValue,
   setOpenMiningAuthForm,
 }: {
+  formState: FormState<SettingsInputs>
   control: Control<SettingsInputs>
   values: SettingsInputs
   setValue: UseFormSetValue<SettingsInputs>
@@ -50,7 +57,13 @@ const MiningSettings = ({
         <Controller
           name='mining.merged.address'
           control={control}
-          rules={{ required: true, minLength: 1 }}
+          rules={{
+            required: true,
+            minLength: {
+              value: 12,
+              message: t.mining.settings.moneroAddressError,
+            },
+          }}
           render={({ field }) => (
             <Input
               placeholder={t.mining.setup.addressPlaceholder}
@@ -59,6 +72,7 @@ const MiningSettings = ({
               value={field.value?.toString()}
               onChange={v => field.onChange(v)}
               autoFocus
+              error={formState.errors.mining?.merged?.address?.message}
             />
           )}
         />

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings/MiningSettings.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings/MiningSettings.tsx
@@ -114,6 +114,7 @@ const MiningSettings = ({
               }}
               value={field?.value?.toString() || ''}
               containerStyle={{ maxWidth: 96 }}
+              withError={false}
             />
           )}
         />

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings/MoneroURL/styles.ts
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings/MoneroURL/styles.ts
@@ -5,7 +5,7 @@ export const StyledMoneroURL = styled.div`
   border-radius: ${({ theme }) => theme.borderRadius()};
   padding: ${({ theme }) => theme.spacingHorizontal(0.67)};
   margin-bottom: ${({ theme }) => theme.spacingVertical(1)};
-  padding-bottom: ${({ theme }) => theme.spacingHorizontal(2.3)};
+  padding-bottom: ${({ theme }) => theme.spacingHorizontal(1.8)};
 
   &:hover {
     background: ${({ theme }) => theme.backgroundSecondary};

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings/index.tsx
@@ -1,13 +1,15 @@
 import MiningSettings from './MiningSettings'
-import { Control, UseFormSetValue } from 'react-hook-form'
+import { Control, FormState, UseFormSetValue } from 'react-hook-form'
 import { SettingsInputs } from '../types'
 
 const MiningSettingsContainer = ({
+  formState,
   control,
   values,
   setValue,
   setOpenMiningAuthForm,
 }: {
+  formState: FormState<SettingsInputs>
   control: Control<SettingsInputs>
   values: SettingsInputs
   setValue: UseFormSetValue<SettingsInputs>
@@ -15,6 +17,7 @@ const MiningSettingsContainer = ({
 }) => {
   return (
     <MiningSettings
+      formState={formState}
       control={control}
       values={values}
       setValue={setValue}

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings/styles.ts
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/MiningSettings/styles.ts
@@ -1,8 +1,6 @@
 import styled from 'styled-components'
 
 export const AddressDescription = styled.div`
-  margin-top: ${({ theme }) => theme.spacingVertical(1)};
-
   & > p {
     color: ${({ theme }) => theme.secondary};
   }

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
@@ -35,6 +35,7 @@ const renderSettings = (
     case Settings.Mining:
       return (
         <MiningSettings
+          formState={props.formState}
           control={props.control}
           values={props.values}
           setValue={props.setValue}
@@ -112,6 +113,7 @@ const SettingsComponent = ({
           </Sidebar>
           <MainContent>
             {renderSettings(activeSettings, {
+              formState,
               control,
               values,
               setValue,

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/types.ts
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/types.ts
@@ -4,6 +4,7 @@ import { Settings } from '../../store/settings/types'
 import { Network } from '../BaseNodeContainer/types'
 
 export type SettingsProps = {
+  formState: FormState<SettingsInputs>
   control: Control<SettingsInputs>
   values: SettingsInputs
   setValue: UseFormSetValue<SettingsInputs>

--- a/applications/launchpad/gui-react/src/locales/mining.ts
+++ b/applications/launchpad/gui-react/src/locales/mining.ts
@@ -72,6 +72,7 @@ const translations = {
       'This is the address to which the Monero coins you earn will be sent.',
     moneroAddressDesc2:
       'You need to provide a Monero address to be able to start Merged mining.',
+    moneroAddressError: 'The address must be at least 12 characters',
     threadsLabel: 'SHA3 threads',
     moneroUrlLabel: 'Monero node URL',
     addNextUrl: 'Add next URL',


### PR DESCRIPTION
Description
---

- [x] 1) added validation on the Monero address length
- [x] 2) added spacing to the Input component that will preserve room for the error, so the layout doesn't jump up & down.

(2) - Because not all inputs have to handle errors and have this `margin-bottom`, the `Input` component has a new optional prop: `withError = true`. If set to false, Input is rendered with no extra spacing.

Motivation and Context
---

#235 

How Has This Been Tested?
---

New address in settings:

![image](https://user-images.githubusercontent.com/11715931/174777153-6739cc9d-9680-48d3-b199-09184ec05691.png)


Docker inspect:

![image](https://user-images.githubusercontent.com/11715931/174777034-0b99f116-fecd-4343-b554-09ec4cd03b34.png)

Spacing for the error in the Input component:

https://user-images.githubusercontent.com/11715931/174777324-37a3ce8d-c051-4eb3-b4d6-2fee2e521931.mov


https://user-images.githubusercontent.com/11715931/174777557-2414ea1d-3336-46e6-b8b7-5e9f5a732993.mov


