### PR TITLE
chore: theme switch to settings

### DIFF
--- a/applications/launchpad/gui-react/src/components/Switch/index.tsx
+++ b/applications/launchpad/gui-react/src/components/Switch/index.tsx
@@ -47,8 +47,14 @@ const Switch = ({
     left: value ? 10 : -1,
   })
 
-  const labelColorAnim = useSpring({
+  const leftLabelColorAnim = useSpring({
     color: disable ? themeStyle.disabledText : themeStyle.primary,
+    opacity: value && leftLabel && rightLabel ? 0.5 : 1,
+  })
+
+  const rightLabelColorAnim = useSpring({
+    color: disable ? themeStyle.disabledText : themeStyle.primary,
+    opacity: value || !leftLabel || !rightLabel ? 1 : 0.5,
   })
 
   const controllerAnim = useSpring({
@@ -57,7 +63,11 @@ const Switch = ({
 
   const leftLabelEl =
     leftLabel && typeof leftLabel === 'string' ? (
-      <Text as={animated.span} type='smallMedium' style={{ ...labelColorAnim }}>
+      <Text
+        as={animated.span}
+        type='smallMedium'
+        style={{ ...leftLabelColorAnim }}
+      >
         {leftLabel}
       </Text>
     ) : (
@@ -65,7 +75,11 @@ const Switch = ({
     )
   const rightLabelEl =
     rightLabel && typeof rightLabel === 'string' ? (
-      <Text as={animated.span} type='smallMedium' style={{ ...labelColorAnim }}>
+      <Text
+        as={animated.span}
+        type='smallMedium'
+        style={{ ...rightLabelColorAnim }}
+      >
         {rightLabel}
       </Text>
     ) : (
@@ -82,7 +96,7 @@ const Switch = ({
         <LabelText
           style={{
             marginRight: 12,
-            ...labelColorAnim,
+            ...leftLabelColorAnim,
           }}
         >
           {leftLabelEl}
@@ -97,7 +111,7 @@ const Switch = ({
         <LabelText
           style={{
             marginLeft: 12,
-            ...labelColorAnim,
+            ...rightLabelColorAnim,
           }}
         >
           {rightLabelEl}

--- a/applications/launchpad/gui-react/src/components/Text/types.ts
+++ b/applications/launchpad/gui-react/src/components/Text/types.ts
@@ -28,7 +28,9 @@ export interface TextProps {
   type?: TextType
   children: ReactNode
   color?: string
-  style?: CSSProperties | Record<string, SpringValue<string>>
+  style?:
+    | CSSProperties
+    | Record<string, SpringValue<string> | SpringValue<number>>
   as?:
     | 'h1'
     | 'h2'

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/index.tsx
@@ -1,17 +1,9 @@
 import { useState, useRef } from 'react'
 
-import Switch from '../../components/Switch'
-
-import Text from '../../components/Text'
-import SvgSun from '../../styles/Icons/Sun'
-import SvgMoon from '../../styles/Icons/Moon'
-
 import MiningHeaderTip from './MiningHeaderTip'
 import MiningViewActions from './MiningViewActions'
 
-import { useAppSelector, useAppDispatch } from '../../store/hooks'
-import { setTheme } from '../../store/app'
-import { selectTheme } from '../../store/app/selectors'
+import { useAppDispatch } from '../../store/hooks'
 import { actions as settingsActions } from '../../store/settings'
 
 import { NodesContainer } from './styles'
@@ -25,7 +17,6 @@ import Statistics from './Statistics'
  */
 const MiningContainer = () => {
   const dispatch = useAppDispatch()
-  const currentTheme = useAppSelector(selectTheme)
   const [schedulingOpen, setSchedulingOpen] = useState(false)
   const [statisticsOpen, setStatisticsOpen] = useState(false)
   const anchorElRef = useRef<HTMLAnchorElement>(null)
@@ -61,24 +52,6 @@ const MiningContainer = () => {
         }}
       />
       <a id='anchorForScroll' ref={anchorElRef} />
-
-      <div style={{ marginTop: 80 }}>
-        <button onClick={() => dispatch(setTheme('light'))}>
-          Set light theme
-        </button>
-        <button onClick={() => dispatch(setTheme('dark'))}>
-          Set dark theme
-        </button>
-        <div>
-          <Text>Select theme</Text>
-          <Switch
-            leftLabel={<SvgSun width='1.4em' height='1.4em' />}
-            rightLabel={<SvgMoon width='1.4em' height='1.4em' />}
-            value={currentTheme === 'dark'}
-            onClick={v => dispatch(setTheme(v ? 'dark' : 'light'))}
-          />
-        </div>
-      </div>
     </div>
   )
 }

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
@@ -3,7 +3,12 @@ import { ReactNode } from 'react'
 import { Settings } from '../../store/settings/types'
 import Modal from '../../components/Modal'
 import Button from '../../components/Button'
+import Switch from '../../components/Switch'
 import Text from '../../components/Text'
+
+import SvgSun from '../../styles/Icons/Sun'
+import SvgMoon from '../../styles/Icons/Moon'
+
 import t from '../../locales'
 
 import {
@@ -14,6 +19,9 @@ import {
   MainContent,
   Footer,
   DiscardWarning,
+  SidebarTabs,
+  SidebarSelectTheme,
+  SwitchBg,
 } from './styles'
 import BaseNodeSettings from './BaseNodeSettings'
 import MiningSettings from './MiningSettings'
@@ -25,6 +33,7 @@ import {
   AuthenticationInputs,
 } from './types'
 import MoneroAuthentication from './MiningSettings/MoneroAuthentication'
+import { useTheme } from 'styled-components'
 
 const renderSettings = (
   settings: Settings,
@@ -76,7 +85,11 @@ const SettingsComponent = ({
   discardChanges,
   openMiningAuthForm,
   setOpenMiningAuthForm,
+  currentTheme,
+  changeTheme,
 }: SettingsComponentProps) => {
+  const theme = useTheme()
+
   // Render Monero Authentication form if open:
   if (openMiningAuthForm) {
     return (
@@ -102,25 +115,42 @@ const SettingsComponent = ({
       <MainContainer data-testid='settings-modal-container'>
         <MainContentContainer>
           <Sidebar>
-            {Object.values(Settings)
-              .filter(settingPage => t.common.nouns[settingPage])
-              .map(settingPage => (
-                <MenuItem
-                  key={settingPage}
-                  active={settingPage === activeSettings}
-                  onClick={() => goToSettings(settingPage)}
-                >
-                  <Text
-                    type={
-                      settingPage === activeSettings
-                        ? 'defaultHeavy'
-                        : undefined
-                    }
+            <SidebarTabs>
+              {Object.values(Settings)
+                .filter(settingPage => t.common.nouns[settingPage])
+                .map(settingPage => (
+                  <MenuItem
+                    key={settingPage}
+                    active={settingPage === activeSettings}
+                    onClick={() => goToSettings(settingPage)}
                   >
-                    {t.common.nouns[settingPage]}
-                  </Text>
-                </MenuItem>
-              ))}
+                    <Text
+                      as='span'
+                      type={
+                        settingPage === activeSettings
+                          ? 'smallHeavy'
+                          : 'smallMedium'
+                      }
+                      style={{ paddingTop: 2 }}
+                    >
+                      {t.common.nouns[settingPage]}
+                    </Text>
+                  </MenuItem>
+                ))}
+            </SidebarTabs>
+            <SidebarSelectTheme>
+              <Text type='microMedium' color={theme.secondary}>
+                {t.settings.selectTheme}
+              </Text>
+              <SwitchBg $transparent={currentTheme === 'dark'}>
+                <Switch
+                  leftLabel={<SvgSun width='1.4em' height='1.4em' />}
+                  rightLabel={<SvgMoon width='1.4em' height='1.4em' />}
+                  value={currentTheme === 'dark'}
+                  onClick={v => changeTheme(v ? 'dark' : 'light')}
+                />
+              </SwitchBg>
+            </SidebarSelectTheme>
           </Sidebar>
           <MainContent>
             {renderSettings(activeSettings, {

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/index.tsx
@@ -1,5 +1,7 @@
 import { useMemo, useEffect, useState } from 'react'
 import { useForm, SubmitHandler } from 'react-hook-form'
+import { setTheme } from '../../store/app'
+import { selectTheme } from '../../store/app/selectors'
 
 import { useAppSelector, useAppDispatch } from '../../store/hooks'
 import { selectMergedMiningState } from '../../store/mining/selectors'
@@ -10,6 +12,7 @@ import {
   selectServiceSettings,
 } from '../../store/settings/selectors'
 import { saveSettings } from '../../store/settings/thunks'
+import { ThemeType } from '../../styles/themes/types'
 
 import SettingsComponent from './SettingsComponent'
 import { SettingsInputs } from './types'
@@ -21,6 +24,8 @@ const SettingsContainer = () => {
 
   const miningMerged = useAppSelector(selectMergedMiningState)
   const serviceSettings = useAppSelector(selectServiceSettings)
+
+  const currentTheme = useAppSelector(selectTheme)
 
   const [openMiningAuthForm, setOpenMiningAuthForm] = useState(false)
   const [confirmCancel, setConfirmCancel] = useState(false)
@@ -74,6 +79,10 @@ const SettingsContainer = () => {
     setConfirmCancel(true)
   }
 
+  const changeTheme = (theme: ThemeType) => {
+    dispatch(setTheme(theme))
+  }
+
   const closeAndDiscard = () => {
     setConfirmCancel(false)
     if (formState.isDirty) {
@@ -99,6 +108,8 @@ const SettingsContainer = () => {
       discardChanges={closeAndDiscard}
       openMiningAuthForm={openMiningAuthForm}
       setOpenMiningAuthForm={setOpenMiningAuthForm}
+      currentTheme={currentTheme}
+      changeTheme={changeTheme}
     />
   )
 }

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/styles.ts
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/styles.ts
@@ -20,12 +20,31 @@ export const Sidebar = styled.aside`
   min-width: 160px;
   height: 100%;
   border-right: 1px solid ${({ theme }) => theme.borderColor};
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`
+
+export const SidebarTabs = styled.div`
+  width: 160px;
+  min-width: 160px;
+  border-right: 1px solid ${({ theme }) => theme.borderColor};
   padding-top: ${({ theme }) => theme.spacing(2)};
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   row-gap: ${({ theme }) => theme.spacing(0.75)};
+  justify-content: space-between;
   align-items: flex-end;
+`
+
+export const SidebarSelectTheme = styled.div`
+  padding: ${({ theme }) => theme.spacingVertical(0.67)} 0;
+  padding-left: ${({ theme }) => theme.spacingHorizontal()};
+  box-sizing: border-box;
+  width: 136px;
+  align-self: flex-end;
 `
 
 export const MenuItem = styled.button<{ active?: boolean }>`
@@ -40,10 +59,11 @@ export const MenuItem = styled.button<{ active?: boolean }>`
   background: ${({ theme, active }) =>
     active ? theme.backgroundImage : 'none'};
   box-sizing: border-box;
-  padding: ${({ theme }) => theme.spacingVertical()} 0;
+  padding: ${({ theme }) => theme.spacingVertical(0.67)} 0;
   padding-left: ${({ theme }) => theme.spacingHorizontal()};
   width: 136px;
   color: ${({ theme, active }) => (active ? theme.accent : theme.accentDark)};
+  height: 39px;
 
   &:hover {
     background: ${({ theme }) => theme.backgroundImage};
@@ -93,4 +113,13 @@ export const RowSpacedBetween = styled.div`
   justify-content: space-between;
   align-items: center;
   margin: ${({ theme }) => theme.spacingVertical(0.6)} 0;
+`
+
+export const SwitchBg = styled.div<{ $transparent?: boolean }>`
+  display: inline-flex;
+  background: ${({ theme, $transparent }) =>
+    $transparent ? 'transparent' : theme.backgroundImage};
+  margin-top: ${({ theme }) => theme.spacingVertical(0.67)};
+  padding: ${({ theme }) => theme.spacingVertical(0.5)};
+  border-radius: ${({ theme }) => theme.borderRadius(0.67)};
 `

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/types.ts
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/types.ts
@@ -1,6 +1,7 @@
 import { Control, FormState, UseFormSetValue } from 'react-hook-form'
 import { MergedMiningNodeState, MoneroUrl } from '../../store/mining/types'
 import { Settings } from '../../store/settings/types'
+import { ThemeType } from '../../styles/themes/types'
 import { Network } from '../BaseNodeContainer/types'
 
 export type SettingsProps = {
@@ -54,4 +55,6 @@ export type SettingsComponentProps = {
   discardChanges: () => void
   openMiningAuthForm: boolean
   setOpenMiningAuthForm: (value: boolean) => void
+  currentTheme: ThemeType
+  changeTheme: (theme: ThemeType) => void
 }

--- a/applications/launchpad/gui-react/src/locales/settings.ts
+++ b/applications/launchpad/gui-react/src/locales/settings.ts
@@ -2,4 +2,5 @@ export default {
   discardChanges: 'Discard changes?',
   discardChangesDesc: 'Closing this window will cancel any unsaved changes',
   closeAndDiscard: 'Close & Discard',
+  selectTheme: 'Select theme',
 }


### PR DESCRIPTION
Description
---

- [x] Move theme switch from Mining Container to the Settings Modal
- [x] add different shades on switch labels
- [x] adjust the sizing of Settings tabs in the left sidebar

Motivation and Context
---

How Has This Been Tested?
---


https://user-images.githubusercontent.com/11715931/175508316-79f3157f-15f7-42e9-a30b-5bd2dbef8a3d.mov


