### PR TITLE
feat: blockchain sync

### DIFF
--- a/applications/launchpad/gui-react/src/App.tsx
+++ b/applications/launchpad/gui-react/src/App.tsx
@@ -55,6 +55,8 @@ const OnboardingAppContainer = ({ children }: { children: JSX.Element }) => {
     init()
   }, [])
 
+  useSystemEvents({ dispatch })
+
   if (!initialized) {
     return null
   }

--- a/applications/launchpad/gui-react/src/App.tsx
+++ b/applications/launchpad/gui-react/src/App.tsx
@@ -42,28 +42,6 @@ const OnboardedAppContainer = ({
   return children
 }
 
-const OnboardingAppContainer = ({ children }: { children: JSX.Element }) => {
-  const [initialized, setInitialized] = useState(false)
-  const dispatch = useAppDispatch()
-
-  useEffect(() => {
-    const init = async () => {
-      await dispatch(loadDefaultServiceSettings()).unwrap()
-      setInitialized(true)
-    }
-
-    init()
-  }, [])
-
-  useSystemEvents({ dispatch })
-
-  if (!initialized) {
-    return null
-  }
-
-  return children
-}
-
 const App = () => {
   const dispatch = useAppDispatch()
   const themeConfig = useAppSelector(selectThemeConfig)
@@ -80,6 +58,7 @@ const App = () => {
     callInitActionInStore()
   }, [])
 
+  useSystemEvents({ dispatch })
   useDockerEvents({ dispatch })
 
   return (

--- a/applications/launchpad/gui-react/src/App.tsx
+++ b/applications/launchpad/gui-react/src/App.tsx
@@ -42,6 +42,26 @@ const OnboardedAppContainer = ({
   return children
 }
 
+const OnboardingAppContainer = ({ children }: { children: JSX.Element }) => {
+  const [initialized, setInitialized] = useState(false)
+  const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    const init = async () => {
+      await dispatch(loadDefaultServiceSettings()).unwrap()
+      setInitialized(true)
+    }
+
+    init()
+  }, [])
+
+  if (!initialized) {
+    return null
+  }
+
+  return children
+}
+
 const App = () => {
   const dispatch = useAppDispatch()
   const themeConfig = useAppSelector(selectThemeConfig)

--- a/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
+++ b/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/jsx-key */
 import { useEffect, useRef, useState } from 'react'
+import { appWindow } from '@tauri-apps/api/window'
 
 import Text from '../../Text'
 import t from '../../../locales'
@@ -155,10 +156,7 @@ export const BlockchainSyncStep = ({
         <>
           <Progress progress={progress} time={remainingTime} />
           <CtaButtonContainer style={{ justifyContent: 'center' }}>
-            <Button
-              variant='secondary'
-              onClick={() => dispatch(setOnboardingComplete(true))}
-            >
+            <Button variant='secondary' onClick={() => appWindow.close()}>
               {t.common.verbs.cancel}
             </Button>
           </CtaButtonContainer>

--- a/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
+++ b/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
@@ -1,33 +1,175 @@
 /* eslint-disable react/jsx-key */
+import { useEffect, useRef, useState } from 'react'
+
 import Text from '../../Text'
 import t from '../../../locales'
 import Button from '../../Button'
+
 import { useAppDispatch } from '../../../store/hooks'
 import { setOnboardingComplete } from '../../../store/app'
+import { actions as baseNodeActions } from '../../../store/baseNode'
+import {
+  CtaButtonContainer,
+  FlexContent,
+  ProgressContainer,
+  RemainingTime,
+} from './styles'
+import ProgressBar from '../../ProgressBar'
+import { TBotMessage, TBotMessageHOCProps } from '../../TBot/TBotPrompt/types'
+import { useTheme } from 'styled-components'
 
 /**
  * @TODO - how the Blockchain synchronization should to work?
  */
-const messages = [
-  () => {
-    const dispatch = useAppDispatch()
 
-    return (
-      <>
-        <Text as='span' type='defaultHeavy'>
-          {t.onboarding.lastSteps.message1} ✨💪
+const Progress = ({ progress, time }: { progress: number; time: string }) => {
+  const theme = useTheme()
+
+  return (
+    <ProgressContainer>
+      <Text
+        color={theme.accent}
+        type='smallMedium'
+        style={{
+          alignSelf: 'flex-start',
+          marginBottom: theme.spacingVertical(0.5),
+        }}
+      >
+        {t.onboarding.lastSteps.blockchainIsSyncing}
+      </Text>
+      <ProgressBar value={progress} />
+      <RemainingTime>
+        <Text type='smallMedium'>
+          {time} {t.common.adjectives.remaining.toLowerCase()}
         </Text>
-        <Button
-          variant='button-in-text'
-          onClick={() => dispatch(setOnboardingComplete(true))}
-        >
-          <Text as='span' type='defaultUnder'>
-            Exit data synchronization
-          </Text>
-        </Button>
-      </>
-    )
-  },
-]
+      </RemainingTime>
+    </ProgressContainer>
+  )
+}
 
-export default messages
+export const BlockchainSyncStep = ({
+  pushMessages,
+  updateMessageBoxSize,
+}: {
+  pushMessages: (msgs: TBotMessage[]) => void
+} & TBotMessageHOCProps) => {
+  const dispatch = useAppDispatch()
+
+  const contentRef = useRef<HTMLDivElement | null>(null)
+
+  const [error, setError] = useState(false)
+  const [syncStarted, setSyncStarted] = useState(false)
+  const [syncFinished, setSyncFinished] = useState(false)
+  const [progress, setProgress] = useState(0)
+  const [remainingTime, setRemainingTime] = useState('55 min')
+
+  const startSync = async () => {
+    setSyncStarted(true)
+    pushMessages([
+      {
+        content: <Text>{t.onboarding.lastSteps.message2}</Text>,
+        barFill: 0.875,
+        noSkip: true,
+      },
+    ])
+    try {
+      await dispatch(baseNodeActions.startNode()).unwrap()
+    } catch (e) {
+      setError(true)
+    }
+  }
+
+  useEffect(() => {
+    if (error) {
+      pushMessages([
+        {
+          content: (
+            <>
+              <Text>{t.onboarding.lastSteps.syncError}</Text>
+              <CtaButtonContainer>
+                <Button
+                  variant='secondary'
+                  onClick={() => dispatch(setOnboardingComplete(true))}
+                >
+                  {t.common.verbs.continue}
+                </Button>
+              </CtaButtonContainer>
+            </>
+          ),
+          barFill: 0.875,
+          noSkip: true,
+          wait: 200,
+        },
+      ])
+    }
+  }, [error])
+
+  useEffect(() => {
+    if (syncStarted && updateMessageBoxSize && contentRef.current) {
+      updateMessageBoxSize()
+    }
+  }, [syncStarted])
+
+  useEffect(() => {
+    if (syncFinished) {
+      // dispatch(setOnboardingComplete(true))
+    }
+  }, [syncFinished])
+
+  /** MOCK WAITING FOR BASE NODE EVENT ABOUT SYNC PROGRESS */
+  const intervalRef = useRef<ReturnType<typeof setInterval> | undefined>()
+  const [intervalStarted, setIntervalStarted] = useState(false)
+  useEffect(() => {
+    if (syncStarted && !intervalStarted) {
+      let counter = 1
+      intervalRef.current = setInterval(async () => {
+        setProgress(counter * 10)
+        setRemainingTime(`${55 - counter * 5} min`)
+        if (counter > 6) {
+          setError(true)
+        }
+        if (counter > 10) {
+          setSyncFinished(true)
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          clearInterval(intervalRef.current!)
+        }
+        counter++
+      }, 2000)
+      setIntervalStarted(true)
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return () => clearInterval(intervalRef.current!)
+  }, [syncStarted])
+  /** END OF MOCK WAITING FOR BASE NODE EVENT ABOUT SYNC PROGRESS */
+
+  return (
+    <FlexContent ref={contentRef}>
+      <Text as='span' type='defaultHeavy'>
+        {t.onboarding.lastSteps.message1} ✨💪
+      </Text>
+
+      {!syncStarted && (
+        <CtaButtonContainer>
+          <Button variant='primary' onClick={startSync}>
+            {t.onboarding.dockerInstall.startSyncBtn}
+          </Button>
+        </CtaButtonContainer>
+      )}
+
+      {syncStarted && (
+        <>
+          <Progress progress={progress} time={remainingTime} />
+          <CtaButtonContainer style={{ justifyContent: 'center' }}>
+            <Button
+              variant='secondary'
+              onClick={() => dispatch(setOnboardingComplete(true))}
+            >
+              {t.common.verbs.cancel}
+            </Button>
+          </CtaButtonContainer>
+        </>
+      )}
+    </FlexContent>
+  )
+}

--- a/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
+++ b/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
@@ -112,7 +112,7 @@ export const BlockchainSyncStep = ({
 
   useEffect(() => {
     if (syncFinished) {
-      // dispatch(setOnboardingComplete(true))
+      dispatch(setOnboardingComplete(true))
     }
   }, [syncFinished])
 

--- a/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/styles.ts
+++ b/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/styles.ts
@@ -24,3 +24,24 @@ export const StatusRow = styled.div`
     margin-bottom: 2px;
   }
 `
+
+export const FlexContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+export const ProgressContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: ${({ theme }) => theme.spacingVertical(4)};
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+  max-width: 450px;
+`
+
+export const RemainingTime = styled.div`
+  margin-top: ${({ theme }) => theme.spacingVertical(1.5)};
+  margin-bottom: ${({ theme }) => theme.spacingVertical(2)};
+`

--- a/applications/launchpad/gui-react/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/applications/launchpad/gui-react/src/components/ProgressBar/ProgressBar.test.tsx
@@ -1,0 +1,46 @@
+import { act, render, screen } from '@testing-library/react'
+import { ThemeProvider } from 'styled-components'
+import ProgressBar from '.'
+
+import themes from '../../styles/themes'
+
+describe('ProgressBar', () => {
+  it('should render given value', async () => {
+    await act(async () => {
+      render(
+        <ThemeProvider theme={themes.light}>
+          <ProgressBar value={50} />
+        </ThemeProvider>,
+      )
+    })
+
+    const tipTextEl = screen.getByText('50%')
+    expect(tipTextEl).toBeInTheDocument()
+  })
+
+  it('should render negative values as positive values', async () => {
+    await act(async () => {
+      render(
+        <ThemeProvider theme={themes.light}>
+          <ProgressBar value={-50} />
+        </ThemeProvider>,
+      )
+    })
+
+    const tipTextEl = screen.getByText('50%')
+    expect(tipTextEl).toBeInTheDocument()
+  })
+
+  it('should render 100% for values greater than 100', async () => {
+    await act(async () => {
+      render(
+        <ThemeProvider theme={themes.light}>
+          <ProgressBar value={150} />
+        </ThemeProvider>,
+      )
+    })
+
+    const tipTextEl = screen.getByText('100%')
+    expect(tipTextEl).toBeInTheDocument()
+  })
+})

--- a/applications/launchpad/gui-react/src/components/ProgressBar/index.tsx
+++ b/applications/launchpad/gui-react/src/components/ProgressBar/index.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react'
+import { config, useSpring } from 'react-spring'
+import Text from '../Text'
+import { Track, Fill, StyledProgressBar, Tip } from './styles'
+
+import { ProgressBarProps } from './types'
+
+const limitValue = (value: number) => {
+  return value > 100 ? 100 : Math.abs(value)
+}
+
+/**
+ * Linear progress bar with a tip.
+ * @param {number} value - number from 0-100 range
+ */
+const ProgressBar = ({ value }: ProgressBarProps) => {
+  const trackRef = useRef<HTMLDivElement | null>(null)
+
+  const [width, setWidth] = useState(value)
+
+  useEffect(() => {
+    if (trackRef.current) {
+      const trackWidth = trackRef.current.clientWidth
+      setWidth(Math.round((trackWidth * limitValue(value)) / 100))
+    }
+  }, [value])
+
+  const progressAnim = useSpring({
+    width: width,
+    config: config.gentle,
+  })
+
+  const tipAnim = useSpring({
+    left: width,
+    config: config.gentle,
+  })
+
+  return (
+    <StyledProgressBar>
+      <Track ref={trackRef}>
+        <Fill style={{ ...progressAnim }} $filled={value === 100} />
+        <Tip style={{ ...tipAnim }} className='progressbar-tip'>
+          <Text as='span' type='smallMedium'>
+            {limitValue(value)}%
+          </Text>
+        </Tip>
+      </Track>
+    </StyledProgressBar>
+  )
+}
+
+export default ProgressBar

--- a/applications/launchpad/gui-react/src/components/ProgressBar/styles.ts
+++ b/applications/launchpad/gui-react/src/components/ProgressBar/styles.ts
@@ -1,0 +1,61 @@
+import { animated } from 'react-spring'
+import styled from 'styled-components'
+
+export const StyledProgressBar = styled.div`
+  width: 100%;
+  &:hover .progressbar-tip {
+    opacity: 1;
+  }
+`
+
+export const Track = styled.div`
+  width: 100%;
+  height: 8px;
+  border-radius: ${({ theme }) => theme.borderRadius(4)};
+  background-color: ${({ theme }) => theme.placeholderText};
+  display: inline-block;
+  position: relative;
+`
+
+export const Fill = styled(animated.div)<{ $filled?: boolean }>`
+  background-image: ${({ theme }) => theme.tariGradient};
+  border-top-left-radius: ${({ theme }) => theme.borderRadius(4)};
+  border-bottom-left-radius: ${({ theme }) => theme.borderRadius(4)};
+  border-top-right-radius: ${({ theme, $filled }) =>
+    $filled ? theme.borderRadius(1) : theme.borderRadius(4)};
+  border-bottom-right-radius: ${({ theme, $filled }) =>
+    $filled ? theme.borderRadius(1) : theme.borderRadius(4)};
+  height: 100%;
+  position: absolute;
+`
+
+export const Tip = styled(animated.div)`
+  opacity: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  background: ${({ theme }) => theme.accent};
+  color: #fff;
+  width: 64px;
+  height: 34px;
+  top: -50px;
+  margin-left: -32px;
+  border-radius: ${({ theme }) => theme.borderRadius(0.5)};
+  box-shadow: 0px 6.00823px 6.00823px rgba(50, 50, 71, 0.08),
+    0px 6.00823px 12.0165px rgba(50, 50, 71, 0.06);
+
+  &:after {
+    content: '';
+    border-right: 12px solid transparent;
+    border-left: 12px solid transparent;
+    position: absolute;
+    border-top: 12px solid ${({ theme }) => theme.accent};
+    width: 0;
+    height: 0;
+    left: 50%;
+    margin-left: -12px;
+    bottom: -8px;
+    border-radius: 2px;
+  }
+`

--- a/applications/launchpad/gui-react/src/components/ProgressBar/types.ts
+++ b/applications/launchpad/gui-react/src/components/ProgressBar/types.ts
@@ -1,0 +1,3 @@
+export interface ProgressBarProps {
+  value: number
+}

--- a/applications/launchpad/gui-react/src/components/TBot/TBotPrompt/MessageBox.tsx
+++ b/applications/launchpad/gui-react/src/components/TBot/TBotPrompt/MessageBox.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactNode, ForwardedRef } from 'react'
+import { forwardRef, ReactNode, ForwardedRef, useState, useRef } from 'react'
 import { useSpring } from 'react-spring'
 import { useTheme } from 'styled-components'
 import SvgArrowRight from '../../../styles/Icons/ArrowRight'
@@ -11,6 +11,7 @@ import {
   MessageSlideIn,
   SkipButtonContainer,
 } from './styles'
+import React from 'react'
 
 /**
  * Component renders the message wrapped with elements allowing to perform
@@ -32,6 +33,9 @@ const MessageBox = (
   },
   ref?: ForwardedRef<HTMLDivElement>,
 ) => {
+  const messageBoxRef = useRef<HTMLDivElement | null>(null)
+  const [heightCtrl, setHeightCtrl] = useState<number | string | undefined>()
+
   const useOpacityAnim = useSpring({
     from: { opacity: animate ? 0 : 1 },
     to: { opacity: 1 },
@@ -46,10 +50,16 @@ const MessageBox = (
 
   const theme = useTheme()
 
+  const updateMessageBoxSize = () => {
+    if (messageBoxRef.current) {
+      setHeightCtrl(messageBoxRef.current.clientHeight)
+    }
+  }
+
   return (
     <StyledMessageBox ref={ref}>
       <StyledMessage
-        style={{ opacity: 0 }}
+        style={{ opacity: 0, height: heightCtrl ? heightCtrl : 'auto' }}
         $skipButton={skipButton}
         $floating={floating}
       >
@@ -58,11 +68,17 @@ const MessageBox = (
       <MessageSpaceContainer>
         <MessageSlideIn style={{ ...useSlideInAnim }}>
           <StyledMessage
+            ref={messageBoxRef}
             style={{ ...useOpacityAnim }}
             $skipButton={skipButton}
             $floating={floating}
           >
-            {children}
+            {React.Children.map(children, child => {
+              if (React.isValidElement(child)) {
+                return React.cloneElement(child, { updateMessageBoxSize })
+              }
+              return child
+            })}
             {skipButton && (
               <SkipButtonContainer>
                 <Button

--- a/applications/launchpad/gui-react/src/components/TBot/TBotPrompt/MessageBox.tsx
+++ b/applications/launchpad/gui-react/src/components/TBot/TBotPrompt/MessageBox.tsx
@@ -75,6 +75,16 @@ const MessageBox = (
           >
             {React.Children.map(children, child => {
               if (React.isValidElement(child)) {
+                /**
+                 * TBot Prompt adds each message twice to the DOM:
+                 * first message is hidden, and its role is to create a space in the layout for the second message.
+                 * The second message is animated and absolutely positioned.
+                 * In some cases, the content of the visible message can be changed,
+                 * and the size may change. So it may result in covering next message.
+                 * To solve this issue, the children should fire `updateMessageBoxSize()`
+                 * whenever the content changes the box sizes. The `updateMessageBoxSize`
+                 * updates the size of hidden message, so the visible message fits the layout.
+                 */
                 return React.cloneElement(child, { updateMessageBoxSize })
               }
               return child

--- a/applications/launchpad/gui-react/src/components/TBot/TBotPrompt/types.ts
+++ b/applications/launchpad/gui-react/src/components/TBot/TBotPrompt/types.ts
@@ -21,3 +21,7 @@ export interface TBotPromptProps {
   onMessageRender?: (index: number) => void
   onSkip?: () => void
 }
+
+export interface TBotMessageHOCProps {
+  updateMessageBoxSize?: () => void
+}

--- a/applications/launchpad/gui-react/src/config/onboardingMessagesConfig.tsx
+++ b/applications/launchpad/gui-react/src/config/onboardingMessagesConfig.tsx
@@ -7,7 +7,7 @@ import {
   DownloadImagesMessage,
   DownloadImagesErrorMessage,
 } from '../components/Onboarding/OnboardingMessages/DockerImagesMessages'
-import lastStepsMessages from '../components/Onboarding/OnboardingMessages/LastStepsMessages'
+import { BlockchainSyncStep } from '../components/Onboarding/OnboardingMessages/LastStepsMessages'
 
 export const OnboardingMessagesIntro: TBotMessage[] = [
   {
@@ -73,13 +73,5 @@ export const OnboardingMessagesDockerInstallAfter: TBotMessage[] = [
   },
 ]
 
-export const OnboardingMessagesLastSteps: TBotMessage[] = [
-  {
-    content: lastStepsMessages[0],
-    barFill: 0.875,
-    wait: 3000,
-    noSkip: true,
-  },
-]
-
+export { BlockchainSyncStep }
 export { DownloadImagesMessage, DownloadImagesErrorMessage }

--- a/applications/launchpad/gui-react/src/containers/Onboarding/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/Onboarding/index.tsx
@@ -10,7 +10,7 @@ import {
   OnboardingMessagesDockerInstallAfter,
   DownloadImagesMessage,
   DownloadImagesErrorMessage,
-  OnboardingMessagesLastSteps,
+  BlockchainSyncStep,
 } from '../../config/onboardingMessagesConfig'
 import { setOnboardingComplete } from '../../store/app'
 import { selectOnboardingCheckpoint } from '../../store/app/selectors'
@@ -76,7 +76,14 @@ const OnboardingContainer = () => {
 
   /** MOCK FOR DOCKER IMAGE DOWNLOAD */
   const onImagesDowloadSuccess = () => {
-    pushMessages(OnboardingMessagesLastSteps)
+    pushMessages([
+      {
+        content: <BlockchainSyncStep pushMessages={pushMessages} />,
+        barFill: 0.875,
+        wait: 500,
+        noSkip: true,
+      },
+    ])
   }
 
   const onDockerInstallDone = () => {

--- a/applications/launchpad/gui-react/src/locales/common.ts
+++ b/applications/launchpad/gui-react/src/locales/common.ts
@@ -55,6 +55,7 @@ const translations: { [key: string]: { [key: string]: string } } = {
     paused: 'Paused',
     copied: 'Copied',
     recommended: 'Recommended',
+    remaining: 'Remaining',
   },
   conjunctions: {
     or: 'or',

--- a/applications/launchpad/gui-react/src/locales/onboarding.ts
+++ b/applications/launchpad/gui-react/src/locales/onboarding.ts
@@ -42,6 +42,7 @@ const translations = {
       link: 'Take me to installation page',
     },
     afterInstall: 'Easy peasy, lemon squeezy! Congratulations! 👏 Docker is installed on your computer. I knew you could handle it. Now it\'s time for the final stretch.',
+    startSyncBtn: 'Sync the blockchain', 
   },
   dockerImages: {
     message1: {
@@ -59,7 +60,10 @@ const translations = {
     },
   },
   lastSteps: {
-    message1: 'Awesome, everything went smoothly. You are one step away from starting mining.'
+    message1: 'Awesome, everything went smoothly. You are one step away from starting mining.',
+    message2: 'When the data synchronization is completed, the Tari Launchpad dashbord will start automatically. Do not close this window as this will pause the entire process.',
+    syncError: 'Ups! Something went wrong!',
+    blockchainIsSyncing: 'Blockchain is synchronizing...',
   },
   expertView: {
     title: 'Pulling images',

--- a/applications/launchpad/gui-react/src/locales/onboarding.ts
+++ b/applications/launchpad/gui-react/src/locales/onboarding.ts
@@ -61,7 +61,7 @@ const translations = {
   },
   lastSteps: {
     message1: 'Awesome, everything went smoothly. You are one step away from starting mining.',
-    message2: 'When the data synchronization is completed, the Tari Launchpad dashbord will start automatically. Do not close this window as this will pause the entire process.',
+    message2: 'When the data synchronization is completed, the Tari Launchpad dashboard will start automatically. Do not close this window as this will pause the entire process.',
     syncError: 'Ups! Something went wrong!',
     blockchainIsSyncing: 'Blockchain is synchronizing...',
   },

--- a/applications/launchpad/gui-react/src/locales/onboarding.ts
+++ b/applications/launchpad/gui-react/src/locales/onboarding.ts
@@ -62,7 +62,7 @@ const translations = {
   lastSteps: {
     message1: 'Awesome, everything went smoothly. You are one step away from starting mining.',
     message2: 'When the data synchronization is completed, the Tari Launchpad dashboard will start automatically. Do not close this window as this will pause the entire process.',
-    syncError: 'Ups! Something went wrong!',
+    syncError: 'Oops! Something went wrong!',
     blockchainIsSyncing: 'Blockchain is synchronizing...',
   },
   expertView: {


### PR DESCRIPTION
Description
---

- [x] Add `ProgressBar` component
- [x] Add Blockchain sync step to the onboarding that start the BaseNode

In next PRs:

- listen to the backend events about Blockchain sync status, and replace mocked `progress` and `remaining time` values

Motivation and Context
---

#319 (partial implementation)

How Has This Been Tested?
---


https://user-images.githubusercontent.com/11715931/175574907-6357ebc4-917a-4340-bf0d-f85f5217481b.mov


