### PR TITLE
feat: refactor container state to use backend recipes

### DIFF
--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -91,6 +91,8 @@ pub fn image_list(settings: ServiceSettings) -> ImageList {
     let recipes: Vec<Vec<String>> = [
         [ImageType::BaseNode.container_name().to_string(), ImageType::Tor.container_name().to_string()].to_vec(),
         [ImageType::Wallet.container_name().to_string(), ImageType::BaseNode.container_name().to_string(), ImageType::Tor.container_name().to_string()].to_vec(),
+        [ImageType::Sha3Miner.container_name().to_string(), ImageType::Wallet.container_name().to_string(), ImageType::BaseNode.container_name().to_string(), ImageType::Tor.container_name().to_string()].to_vec(),
+        [ImageType::MmProxy.container_name().to_string(), ImageType::XmRig.container_name().to_string(), ImageType::Monerod.container_name().to_string(), ImageType::Wallet.container_name().to_string(), ImageType::BaseNode.container_name().to_string(), ImageType::Tor.container_name().to_string()].to_vec(),
     ].to_vec();
 
     ImageList {

--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -92,7 +92,7 @@ pub fn image_info(settings: ServiceSettings) -> ImageListDto {
         [ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
         [ImageType::Wallet, ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
         [ImageType::Sha3Miner, ImageType::Wallet, ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
-        [ImageType::MmProxy, ImageType::XmRig, ImageType::Monerod, ImageType::Wallet, ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
+        [ImageType::MmProxy, ImageType::XmRig, ImageType::Wallet, ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
     ].to_vec();
 
     ImageListDto {

--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -89,15 +89,39 @@ pub fn image_info(settings: ServiceSettings) -> ImageListDto {
         .collect();
 
     let recipes: Vec<Vec<String>> = [
-        [ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
-        [ImageType::Wallet, ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
-        [ImageType::Sha3Miner, ImageType::Wallet, ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
-        [ImageType::MmProxy, ImageType::XmRig, ImageType::Wallet, ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
-    ].to_vec();
+        [ImageType::BaseNode, ImageType::Tor]
+            .iter()
+            .map(|image_type| image_type.container_name().to_string())
+            .collect(),
+        [ImageType::Wallet, ImageType::BaseNode, ImageType::Tor]
+            .iter()
+            .map(|image_type| image_type.container_name().to_string())
+            .collect(),
+        [
+            ImageType::Sha3Miner,
+            ImageType::Wallet,
+            ImageType::BaseNode,
+            ImageType::Tor,
+        ]
+        .iter()
+        .map(|image_type| image_type.container_name().to_string())
+        .collect(),
+        [
+            ImageType::MmProxy,
+            ImageType::XmRig,
+            ImageType::Wallet,
+            ImageType::BaseNode,
+            ImageType::Tor,
+        ]
+        .iter()
+        .map(|image_type| image_type.container_name().to_string())
+        .collect(),
+    ]
+    .to_vec();
 
     ImageListDto {
         image_info: images,
-        service_recipes: recipes
+        service_recipes: recipes,
     }
 }
 

--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -58,7 +58,7 @@ pub struct ImageInfo {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct ImageList {
+pub struct ImageListDto {
     image_info: Vec<ImageInfo>,
     service_recipes: Vec<Vec<String>>,
 }
@@ -72,9 +72,9 @@ pub fn network_list() -> Vec<String> {
     enum_to_list::<TariNetwork>(&TARI_NETWORKS)
 }
 
-/// Provide a list of image names in the Tari "ecosystem"
+/// Provide information about docker images and service recipes in Tari "ecosystem"
 #[tauri::command]
-pub fn image_list(settings: ServiceSettings) -> ImageList {
+pub fn image_info(settings: ServiceSettings) -> ImageListDto {
     let registry = settings.docker_registry.as_ref().map(String::as_str);
     let tag = settings.docker_tag.as_ref().map(String::as_str);
 
@@ -89,13 +89,13 @@ pub fn image_list(settings: ServiceSettings) -> ImageList {
         .collect();
 
     let recipes: Vec<Vec<String>> = [
-        [ImageType::BaseNode.container_name().to_string(), ImageType::Tor.container_name().to_string()].to_vec(),
-        [ImageType::Wallet.container_name().to_string(), ImageType::BaseNode.container_name().to_string(), ImageType::Tor.container_name().to_string()].to_vec(),
-        [ImageType::Sha3Miner.container_name().to_string(), ImageType::Wallet.container_name().to_string(), ImageType::BaseNode.container_name().to_string(), ImageType::Tor.container_name().to_string()].to_vec(),
-        [ImageType::MmProxy.container_name().to_string(), ImageType::XmRig.container_name().to_string(), ImageType::Monerod.container_name().to_string(), ImageType::Wallet.container_name().to_string(), ImageType::BaseNode.container_name().to_string(), ImageType::Tor.container_name().to_string()].to_vec(),
+        [ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
+        [ImageType::Wallet, ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
+        [ImageType::Sha3Miner, ImageType::Wallet, ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
+        [ImageType::MmProxy, ImageType::XmRig, ImageType::Monerod, ImageType::Wallet, ImageType::BaseNode, ImageType::Tor].iter().map(|image_type| image_type.container_name().to_string()).collect(),
     ].to_vec();
 
-    ImageList {
+    ImageListDto {
         image_info: images,
         service_recipes: recipes
     }

--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -51,6 +51,7 @@ pub static TARI_NETWORKS: [TariNetwork; 3] = [TariNetwork::Dibbler, TariNetwork:
 #[serde(rename_all = "camelCase")]
 pub struct ImageInfo {
     image_name: String,
+    container_name: String,
     display_name: String,
     docker_image: String,
 }
@@ -73,6 +74,7 @@ pub fn image_list(settings: ServiceSettings) -> Vec<ImageInfo> {
         .iter()
         .map(|value| ImageInfo {
             image_name: value.image_name().to_string(),
+            container_name: value.container_name().to_string(),
             display_name: value.display_name().to_string(),
             docker_image: TariWorkspace::fully_qualified_image(*value, registry, tag),
         })

--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -89,7 +89,8 @@ pub fn image_list(settings: ServiceSettings) -> ImageList {
         .collect();
 
     let recipes: Vec<Vec<String>> = [
-        [ImageType::BaseNode.container_name().to_string(), ImageType::Tor.container_name().to_string()].to_vec()
+        [ImageType::BaseNode.container_name().to_string(), ImageType::Tor.container_name().to_string()].to_vec(),
+        [ImageType::Wallet.container_name().to_string(), ImageType::BaseNode.container_name().to_string(), ImageType::Tor.container_name().to_string()].to_vec(),
     ].to_vec();
 
     ImageList {

--- a/applications/launchpad/backend/src/commands/pull_images.rs
+++ b/applications/launchpad/backend/src/commands/pull_images.rs
@@ -42,14 +42,13 @@ pub struct Payload {
     info: CreateImageInfo,
 }
 
-pub static DEFAULT_IMAGES: [ImageType; 10] = [
+pub static DEFAULT_IMAGES: [ImageType; 9] = [
     ImageType::BaseNode,
     ImageType::Wallet,
     ImageType::Sha3Miner,
     ImageType::Tor,
     ImageType::MmProxy,
     ImageType::XmRig,
-    ImageType::Monerod,
     ImageType::Loki,
     ImageType::Promtail,
     ImageType::Grafana,

--- a/applications/launchpad/backend/src/main.rs
+++ b/applications/launchpad/backend/src/main.rs
@@ -38,7 +38,7 @@ use tauri::{
 use tauri_plugin_sql::{Migration, MigrationKind, TauriSql};
 
 use crate::{
-    api::{image_list, network_list, wallet_balance, wallet_events, wallet_identity},
+    api::{image_info, network_list, wallet_balance, wallet_events, wallet_identity},
     commands::{
         create_default_workspace,
         create_new_workspace,
@@ -127,7 +127,7 @@ fn main() {
         .manage(AppState::new(docker, workspaces, package_info))
         .menu(menu)
         .invoke_handler(tauri::generate_handler![
-            image_list,
+            image_info,
             network_list,
             pull_images,
             create_new_workspace,

--- a/applications/launchpad/gui-react/__tests__/mocks/mockTauriIPC.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/mockTauriIPC.ts
@@ -60,7 +60,7 @@ export const tauriIPCMock = (props: Record<string, unknown> = {}) => {
         } as ServiceDescriptor
       case 'stop_service':
         return true
-      case 'image_list':
+      case 'image_info':
         return []
       default:
         return

--- a/applications/launchpad/gui-react/__tests__/mocks/mockTauriIPC.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/mockTauriIPC.ts
@@ -61,7 +61,7 @@ export const tauriIPCMock = (props: Record<string, unknown> = {}) => {
       case 'stop_service':
         return true
       case 'image_info':
-        return []
+        return { imageInfo: [], serviceRecipes: [] }
       default:
         return
     }
@@ -69,7 +69,7 @@ export const tauriIPCMock = (props: Record<string, unknown> = {}) => {
 }
 
 const tauriCmdMock = (
-  cmd: string,
+  _cmd: string,
   args: Record<string, unknown>,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   props: Record<string, any>,

--- a/applications/launchpad/gui-react/__tests__/mocks/states/containersStateTemplates.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/states/containersStateTemplates.ts
@@ -24,7 +24,7 @@ const runningContainers = (cs: Container[]) => {
 
   cs.forEach(c => {
     containers[`${c.toLowerCase()}-id`] = {
-      type: c,
+      name: c,
       error: undefined,
       status: SystemEventAction.Start,
       timestamp: Number(Date.now()),

--- a/applications/launchpad/gui-react/__tests__/mocks/states/containersStateTemplates.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/states/containersStateTemplates.ts
@@ -15,7 +15,9 @@ const noErrors = {
   [Container.MMProxy]: undefined,
   [Container.XMrig]: undefined,
   [Container.Monerod]: undefined,
-  [Container.Frontail]: undefined,
+  [Container.Loki]: undefined,
+  [Container.Promtail]: undefined,
+  [Container.Grafana]: undefined,
 }
 
 const runningContainers = (cs: Container[]) => {
@@ -31,7 +33,7 @@ const runningContainers = (cs: Container[]) => {
     }
 
     stats[`${c.toLowerCase()}-id`] = {
-      timestamp: '',
+      network: { upload: 0, download: 0 },
       cpu: 0,
       memory: 0,
       unsubscribe: () => {
@@ -48,7 +50,7 @@ const zeroedStatsForContainers = (cs: Container[]) => {
 
   cs.forEach(c => {
     stats[`${c.toLowerCase()}-id`] = {
-      timestamp: '',
+      network: { upload: 0, download: 0 },
       cpu: 0,
       memory: 0,
       unsubscribe: () => {

--- a/applications/launchpad/gui-react/__tests__/mocks/states/dockerImagesStateTemplates.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/states/dockerImagesStateTemplates.ts
@@ -1,5 +1,0 @@
-export const defaultDockerImages = {
-  pending: false,
-  images: [],
-  recipes: [],
-}

--- a/applications/launchpad/gui-react/__tests__/mocks/states/dockerImagesStateTemplates.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/states/dockerImagesStateTemplates.ts
@@ -1,0 +1,5 @@
+export const defaultDockerImages = {
+  pending: false,
+  images: [],
+  recipes: [],
+}

--- a/applications/launchpad/gui-react/__tests__/mocks/states/index.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/states/index.ts
@@ -1,4 +1,3 @@
 export * from './containersStateTemplates'
 export * from './miningStateTemplates'
 export * from './walletStateTemplates'
-export * from './dockerImagesStateTemplates'

--- a/applications/launchpad/gui-react/__tests__/mocks/states/index.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/states/index.ts
@@ -1,3 +1,4 @@
 export * from './containersStateTemplates'
 export * from './miningStateTemplates'
 export * from './walletStateTemplates'
+export * from './dockerImagesStateTemplates'

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/Containers.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/Containers.tsx
@@ -38,10 +38,10 @@ const Containers = ({ containers, stop, start }: ContainersProps) => {
       <ContainersTable>
         <tbody>
           {containers.map(container => (
-            <tr key={container.container}>
+            <tr key={container.imageName}>
               <td>
                 <Text color={theme.inverted.primary}>
-                  {t.common.containers[container.container]}
+                  {container.displayName}
                 </Text>
               </td>
               <TdRight>

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
@@ -33,7 +33,7 @@ const ContainersContainer = () => {
 
   const start = async (container: Container) => {
     try {
-      await dispatch(actions.start({ service: container })).unwrap()
+      await dispatch(actions.start({ container: container })).unwrap()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (e: any) {
       setError(e.toString())

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/index.tsx
@@ -15,15 +15,19 @@ const ContainersContainer = () => {
   const containerStatuses = useAppSelector(selectContainersStatusesWithStats)
   const containers = useMemo(
     () =>
-      containerStatuses.map(({ container, status }) => ({
-        id: status.id,
-        container: container as Container,
-        error: status.error,
-        cpu: status.stats.cpu,
-        memory: status.stats.memory,
-        pending: status.pending,
-        running: status.running,
-      })),
+      containerStatuses.map(
+        ({ container, imageName, displayName, status }) => ({
+          id: status.id,
+          container: container as Container,
+          imageName,
+          displayName,
+          error: status.error,
+          cpu: status.stats.cpu,
+          memory: status.stats.memory,
+          pending: status.pending,
+          running: status.running,
+        }),
+      ),
     [containerStatuses],
   )
 

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/types.ts
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Containers/types.ts
@@ -1,4 +1,5 @@
 import { Container, ContainerId } from '../../../../store/containers/types'
+import { DockerImage } from '../../../../types/general'
 
 type ContainerDto = {
   id: ContainerId
@@ -9,7 +10,7 @@ type ContainerDto = {
   memory: number
   pending: boolean
   running: boolean
-}
+} & Pick<DockerImage, 'imageName' | 'displayName'>
 
 export type ContainersProps = {
   containers: ContainerDto[]

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/usePerformanceStats.ts
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/usePerformanceStats.ts
@@ -6,6 +6,7 @@ import getStatsRepository, {
   StatsEntry,
 } from '../../../../persistence/statsRepository'
 import { Container } from '../../../../store/containers/types'
+import { selectDockerImages } from '../../../../store/dockerImages/selectors'
 import { Dictionary } from '../../../../types/general'
 
 import { UsePerformanceStatsType } from './types'
@@ -26,6 +27,7 @@ const usePerformanceStats: UsePerformanceStatsType = ({
   extractor,
 }) => {
   const configuredNetwork = useAppSelector(selectNetwork)
+  const dockerImages = useAppSelector(selectDockerImages)
   const repository = useMemo(getStatsRepository, [])
   const [stats, setStats] = useState<Dictionary<StatsEntry[]>>()
 
@@ -48,12 +50,15 @@ const usePerformanceStats: UsePerformanceStatsType = ({
   }, [enabled, from, to])
 
   const extracted = useMemo(() => {
-    const r = Object.values(Container)
-      .filter(container => Boolean(stats && stats[container]))
+    const r = dockerImages
+      .filter(container => Boolean(stats && stats[container.containerName]))
       .reduce(
         (accu, current) => ({
           ...accu,
-          [current]: ((stats && stats[current]) || []).map(extractor),
+          [current.containerName]: (
+            (stats && stats[current.containerName]) ||
+            []
+          ).map(extractor),
         }),
         {} as Record<Container, { timestamp: string; value: number }[]>,
       )

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/MiningBox.test.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningBox/MiningBox.test.tsx
@@ -53,7 +53,7 @@ describe('MiningBox', () => {
       error: [{ type: Container.Tor, error: 'Something went wrong' }],
       dependsOn: [
         {
-          type: Container.Tor,
+          containerName: Container.Tor,
           id: 'test-tor-container-id',
           running: false,
           pending: false,

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningContainer.integration.test.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningContainer.integration.test.tsx
@@ -16,11 +16,13 @@ import {
   allStopped,
   initialMining,
   unlockedWallet,
+  defaultDockerImages,
 } from '../../../__tests__/mocks/states'
 import { act } from 'react-dom/test-utils'
 import { Container, SystemEventAction } from '../../store/containers/types'
 
 const rootStateTemplate = {
+  dockerImages: defaultDockerImages,
   wallet: unlockedWallet,
   mining: initialMining,
   containers: allStopped,
@@ -69,7 +71,7 @@ describe('MiningContainer with Redux', () => {
       </Provider>,
     )
 
-    // 2. MiningContainer should by in 'paused' status and render the 'start' button
+    // 2. MiningContainer should be in 'paused' status and render the 'start' button
     let elRunBtn = screen.getByTestId('tari-run-btn')
     expect(elRunBtn).toBeInTheDocument()
 
@@ -87,6 +89,18 @@ describe('MiningContainer with Redux', () => {
           payload: {
             containerId: `${c}-id`,
             action: SystemEventAction.Start,
+          },
+        })
+        store.dispatch({
+          type: 'containers/start/fulfilled',
+          payload: {
+            id: `${c}-id`,
+            unsubscribeStats: () => null,
+          },
+          meta: {
+            arg: {
+              container: c,
+            },
           },
         })
       })

--- a/applications/launchpad/gui-react/src/containers/MiningContainer/MiningContainer.integration.test.tsx
+++ b/applications/launchpad/gui-react/src/containers/MiningContainer/MiningContainer.integration.test.tsx
@@ -16,13 +16,11 @@ import {
   allStopped,
   initialMining,
   unlockedWallet,
-  defaultDockerImages,
 } from '../../../__tests__/mocks/states'
 import { act } from 'react-dom/test-utils'
 import { Container, SystemEventAction } from '../../store/containers/types'
 
 const rootStateTemplate = {
-  dockerImages: defaultDockerImages,
   wallet: unlockedWallet,
   mining: initialMining,
   containers: allStopped,

--- a/applications/launchpad/gui-react/src/persistence/statsRepository.ts
+++ b/applications/launchpad/gui-react/src/persistence/statsRepository.ts
@@ -1,6 +1,6 @@
 import groupby from 'lodash.groupby'
 
-import { Dictionary } from '../types/general'
+import { Dictionary, ContainerName } from '../types/general'
 import {
   Container,
   SerializableContainerStats,
@@ -20,7 +20,7 @@ export interface StatsEntry {
 export interface StatsRepository {
   add: (
     network: string,
-    service: Container,
+    container: ContainerName,
     secondTimestamp: string,
     stats: SerializableContainerStats,
   ) => Promise<void>
@@ -33,7 +33,7 @@ export interface StatsRepository {
 
 const repositoryFactory: () => StatsRepository = () => {
   return {
-    add: async (network, service, secondTimestamp, stats) => {
+    add: async (network, container, secondTimestamp, stats) => {
       const db = await getDb()
 
       await db.execute(
@@ -48,7 +48,7 @@ const repositoryFactory: () => StatsRepository = () => {
         [
           secondTimestamp,
           network,
-          service,
+          container,
           stats.cpu,
           stats.memory,
           stats.network.upload,

--- a/applications/launchpad/gui-react/src/persistence/statsRepository.ts
+++ b/applications/launchpad/gui-react/src/persistence/statsRepository.ts
@@ -1,16 +1,13 @@
 import groupby from 'lodash.groupby'
 
 import { Dictionary, ContainerName } from '../types/general'
-import {
-  Container,
-  SerializableContainerStats,
-} from '../store/containers/types'
+import { SerializableContainerStats } from '../store/containers/types'
 import getDb from './db'
 
 export interface StatsEntry {
   timestamp: string
   network: string
-  service: Container
+  service: ContainerName
   cpu: number
   memory: number
   upload: number

--- a/applications/launchpad/gui-react/src/store/baseNode/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/selectors.ts
@@ -1,9 +1,9 @@
-import { createSelector } from '@reduxjs/toolkit'
-
 import { RootState } from '../'
 import { Container } from '../containers/types'
-import { selectContainerStatus } from '../containers/selectors'
-import { selectRecipe } from '../dockerImages/selectors'
+import {
+  selectRecipeRunning,
+  selectRecipePending,
+} from '../containers/selectors'
 import type { Network } from '../../containers/BaseNodeContainer/types'
 
 import { BaseNodeState } from './types'
@@ -14,21 +14,6 @@ export const selectState = (state: RootState): BaseNodeState => ({
 
 export const selectNetwork = (state: RootState) => state.baseNode.network
 
-const selectContainerStatuses = (rootState: RootState) => {
-  const recipe = selectRecipe(Container.BaseNode)(rootState)
-  return recipe.map(containerType =>
-    selectContainerStatus(containerType)(rootState),
-  )
-}
+export const selectRunning = selectRecipeRunning(Container.BaseNode)
 
-export const selectRunning = createSelector(
-  selectContainerStatuses,
-  containers =>
-    containers.every(container => container.running) ||
-    containers.some(container => container.running && container.pending),
-)
-
-export const selectPending = createSelector(
-  selectContainerStatuses,
-  containers => containers.some(container => container.pending),
-)
+export const selectPending = selectRecipePending(Container.BaseNode)

--- a/applications/launchpad/gui-react/src/store/baseNode/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/thunks.ts
@@ -1,76 +1,23 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import { RootState } from '..'
-import {
-  selectContainerStatus,
-  selectRunningContainers,
-} from '../containers/selectors'
-import { selectRecipe } from '../dockerImages/selectors'
 import { actions as containersActions } from '../containers'
 import { Container } from '../containers/types'
 
 export const startNode = createAsyncThunk<void, void, { state: RootState }>(
   'baseNode/startNode',
-  async (_, thunkApi) => {
-    try {
-      const rootState = thunkApi.getState()
-      const recipe = selectRecipe(Container.BaseNode)(rootState)
-
-      const recipePromises = [...recipe]
-        .reverse()
-        .map(part => {
-          const status = selectContainerStatus(part)(rootState)
-          if (!status.running && !status.pending) {
-            return thunkApi
-              .dispatch(containersActions.start({ container: part }))
-              .unwrap()
-          }
-
-          return false
-        })
-        .filter(Boolean)
-
-      await Promise.all(recipePromises)
-    } catch (e) {
-      return thunkApi.rejectWithValue(e)
-    }
-  },
+  (_, thunkApi) =>
+    thunkApi
+      .dispatch(
+        containersActions.startRecipe({ containerName: Container.BaseNode }),
+      )
+      .unwrap(),
 )
 
 export const stopNode = createAsyncThunk<void, void, { state: RootState }>(
   'baseNode/stopNode',
-  async (_, thunkApi) => {
-    try {
-      const rootState = thunkApi.getState()
-      const recipe = selectRecipe(Container.BaseNode)(rootState)
-
-      const [head, ...tail] = recipe.map(part =>
-        selectContainerStatus(part)(rootState),
-      )
-
-      thunkApi.dispatch(containersActions.stop(head.id))
-
-      const runningContainers = selectRunningContainers(rootState)
-      const containersOutsideRecipe = runningContainers.filter(
-        rc => !recipe.includes(rc),
-      )
-      const containersRequiredByOtherServices = containersOutsideRecipe.reduce(
-        (accu, current) => {
-          const currentRecipe = selectRecipe(current)(rootState)
-          currentRecipe.forEach(cr => accu.add(cr))
-
-          return accu
-        },
-        new Set(),
-      )
-
-      tail
-        .filter(tailPart => !containersRequiredByOtherServices.has(tailPart))
-        .forEach(tailPartToStop =>
-          thunkApi.dispatch(containersActions.stop(tailPartToStop.id)),
-        )
-    } catch (e) {
-      return thunkApi.rejectWithValue(e)
-    }
-  },
+  (_, thunkApi) =>
+    thunkApi
+      .dispatch(containersActions.stopRecipe(Container.BaseNode))
+      .unwrap(),
 )

--- a/applications/launchpad/gui-react/src/store/baseNode/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/thunks.ts
@@ -19,7 +19,7 @@ export const startNode = createAsyncThunk<void, void, { state: RootState }>(
 
       if (!torStatus.running && !torStatus.pending) {
         await thunkApi
-          .dispatch(containersActions.start({ service: Container.Tor }))
+          .dispatch(containersActions.start({ container: Container.Tor }))
           .unwrap()
       }
 
@@ -28,7 +28,7 @@ export const startNode = createAsyncThunk<void, void, { state: RootState }>(
       )
       if (!baseNodeStatus.running && !baseNodeStatus.pending) {
         await thunkApi
-          .dispatch(containersActions.start({ service: Container.BaseNode }))
+          .dispatch(containersActions.start({ container: Container.BaseNode }))
           .unwrap()
       }
     } catch (e) {

--- a/applications/launchpad/gui-react/src/store/containers/index.ts
+++ b/applications/launchpad/gui-react/src/store/containers/index.ts
@@ -91,7 +91,7 @@ const containersSlice = createSlice({
       }
 
       state.pending = state.pending.filter(p => p !== action.meta.arg.service)
-      state.containers[action.payload.id].type = action.meta.arg.service
+      state.containers[action.payload.id].name = action.meta.arg.service
       state.stats[action.payload.id].unsubscribe =
         action.payload.unsubscribeStats
       state.errors[action.meta.arg.service] = undefined
@@ -108,7 +108,7 @@ const containersSlice = createSlice({
     builder.addCase(stop.fulfilled, (state, { meta }) => {
       state.pending = state.pending.filter(p => p !== meta.arg)
       state.containers[meta.arg].error = undefined
-      const type = state.containers[meta.arg].type
+      const type = state.containers[meta.arg].name
       if (type) {
         state.errors[type] = undefined
       }

--- a/applications/launchpad/gui-react/src/store/containers/index.ts
+++ b/applications/launchpad/gui-react/src/store/containers/index.ts
@@ -80,8 +80,8 @@ const containersSlice = createSlice({
   },
   extraReducers: builder => {
     builder.addCase(start.pending, (state, { meta }) => {
-      state.pending.push(meta.arg.service)
-      state.errors[meta.arg.service] = undefined
+      state.pending.push(meta.arg.container)
+      state.errors[meta.arg.container] = undefined
     })
     builder.addCase(start.fulfilled, (state, action) => {
       if (!state.containers[action.payload.id]) {
@@ -90,15 +90,15 @@ const containersSlice = createSlice({
         return
       }
 
-      state.pending = state.pending.filter(p => p !== action.meta.arg.service)
-      state.containers[action.payload.id].name = action.meta.arg.service
+      state.pending = state.pending.filter(p => p !== action.meta.arg.container)
+      state.containers[action.payload.id].name = action.meta.arg.container
       state.stats[action.payload.id].unsubscribe =
         action.payload.unsubscribeStats
-      state.errors[action.meta.arg.service] = undefined
+      state.errors[action.meta.arg.container] = undefined
     })
     builder.addCase(start.rejected, (state, action) => {
-      state.errors[action.meta.arg.service] = action.payload
-      state.pending = state.pending.filter(p => p !== action.meta.arg.service)
+      state.errors[action.meta.arg.container] = action.payload
+      state.pending = state.pending.filter(p => p !== action.meta.arg.container)
     })
 
     builder.addCase(stop.pending, (state, { meta }) => {

--- a/applications/launchpad/gui-react/src/store/containers/index.ts
+++ b/applications/launchpad/gui-react/src/store/containers/index.ts
@@ -6,7 +6,15 @@ import {
   Container,
   SystemEventAction,
 } from './types'
-import { addStats, start, stop, stopByType, restart } from './thunks'
+import {
+  addStats,
+  start,
+  startRecipe,
+  stop,
+  stopRecipe,
+  stopByType,
+  restart,
+} from './thunks'
 
 const getInitialServiceStatus = (
   lastAction: SystemEventAction,
@@ -129,6 +137,14 @@ const containersSlice = createSlice({
 })
 
 const { actions: syncActions } = containersSlice
-export const actions = { start, stop, stopByType, restart, ...syncActions }
+export const actions = {
+  start,
+  startRecipe,
+  stop,
+  stopRecipe,
+  stopByType,
+  restart,
+  ...syncActions,
+}
 
 export default containersSlice.reducer

--- a/applications/launchpad/gui-react/src/store/containers/selectors.test.ts
+++ b/applications/launchpad/gui-react/src/store/containers/selectors.test.ts
@@ -4,7 +4,7 @@ import { ContainerStatusDto, Container, SystemEventAction } from './types'
 import { selectContainerStatus } from './selectors'
 
 describe('containers/selectors', () => {
-  it('should return default state for container if no container of that type is present', () => {
+  it('should return default state for container if no container of that containerName is present', () => {
     // given
     const rootState = {
       containers: {
@@ -15,7 +15,7 @@ describe('containers/selectors', () => {
     } as unknown as RootState
     const expected = {
       id: '',
-      type: Container.Tor,
+      containerName: Container.Tor,
       running: false,
       pending: false,
     }
@@ -38,7 +38,7 @@ describe('containers/selectors', () => {
     } as unknown as RootState
     const expected = {
       id: '',
-      type: Container.Tor,
+      containerName: Container.Tor,
       running: false,
       pending: true,
     }
@@ -50,7 +50,7 @@ describe('containers/selectors', () => {
     expect(JSON.stringify(selected)).toBe(JSON.stringify(expected)) // need to check this way because of unsubscribe function
   })
 
-  it('should return container by type', () => {
+  it('should return container by containerName', () => {
     // given
     const rootState = {
       containers: {
@@ -58,7 +58,7 @@ describe('containers/selectors', () => {
         pending: [],
         containers: {
           containerId: {
-            type: Container.Tor,
+            name: Container.Tor,
             status: SystemEventAction.Start,
           },
         },
@@ -67,7 +67,7 @@ describe('containers/selectors', () => {
     const expected = {
       id: 'containerId',
       status: SystemEventAction.Start,
-      type: Container.Tor,
+      containerName: Container.Tor,
       error: undefined,
       running: true,
       pending: false,
@@ -94,7 +94,7 @@ describe('containers/selectors', () => {
         pending: [],
         containers: {
           containerId: {
-            type: Container.Tor,
+            name: Container.Tor,
             error: containerError,
             status: SystemEventAction.Start,
           },
@@ -111,7 +111,7 @@ describe('containers/selectors', () => {
     expect(selectedContainer.error).toBe(containerError)
   })
 
-  it('should return container by type with error if present', () => {
+  it('should return container by containerName with error if present', () => {
     // given
     const containerTypeError = { some: 'error' }
     const rootState = {
@@ -122,7 +122,7 @@ describe('containers/selectors', () => {
         pending: [],
         containers: {
           containerId: {
-            type: Container.Tor,
+            name: Container.Tor,
             status: SystemEventAction.Start,
           },
         },
@@ -153,7 +153,7 @@ describe('containers/selectors', () => {
           pending: [],
           containers: {
             containerId: {
-              type: Container.Tor,
+              name: Container.Tor,
               status: status,
             },
           },
@@ -170,7 +170,7 @@ describe('containers/selectors', () => {
     }),
   )
 
-  it('should return container with biggest timestamp value if multiple containers of the same type are present', () => {
+  it('should return container with biggest timestamp value if multiple containers of the same containerName are present', () => {
     // given
     const rootState = {
       containers: {
@@ -179,12 +179,12 @@ describe('containers/selectors', () => {
         containers: {
           containerId: {
             timestamp: 0,
-            type: Container.Tor,
+            name: Container.Tor,
             status: SystemEventAction.Start,
           },
           anotherContainerId: {
             timestamp: 1,
-            type: Container.Tor,
+            name: Container.Tor,
             status: SystemEventAction.Start,
           },
         },
@@ -194,7 +194,7 @@ describe('containers/selectors', () => {
       id: 'anotherContainerId',
       timestamp: 1,
       status: SystemEventAction.Start,
-      type: Container.Tor,
+      containerName: Container.Tor,
       error: undefined,
       running: true,
       pending: false,
@@ -217,7 +217,7 @@ describe('containers/selectors', () => {
         pending: [],
         containers: {
           containerId: {
-            type: Container.Tor,
+            name: Container.Tor,
             status: SystemEventAction.Create,
           },
         },
@@ -225,7 +225,7 @@ describe('containers/selectors', () => {
     } as unknown as RootState
     const expected = {
       id: 'containerId',
-      type: Container.Tor,
+      containerName: Container.Tor,
       status: SystemEventAction.Create,
       error: undefined,
       running: false,

--- a/applications/launchpad/gui-react/src/store/containers/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/containers/selectors.ts
@@ -13,9 +13,6 @@ import {
 
 export const selectState = (rootState: RootState) => rootState.containers
 
-export const selectPendingContainers = (rootState: RootState) =>
-  rootState.containers.pending
-
 export const selectContainer = (c: string | Container) => (r: RootState) => {
   const containers = Object.entries(r.containers.containers).filter(
     ([, value]) => value.name === c,
@@ -26,7 +23,7 @@ export const selectContainer = (c: string | Container) => (r: RootState) => {
   return { containerId, containerStatus }
 }
 
-export const selectContainerStats = (containerId: string) => (r: RootState) =>
+const selectContainerStats = (containerId: string) => (r: RootState) =>
   r.containers.stats[containerId]
 
 type ContainerStatusSelector = (
@@ -105,17 +102,6 @@ export const selectRunningContainers = (rootState: RootState): Container[] =>
     )
     .filter(status => status.running)
     .map(status => rootState.containers.containers[status.id].name as Container)
-
-export const selectContainersStatuses = createSelector(
-  selectDockerImages,
-  (rootState: RootState) => rootState,
-  (dockerImages, rootState) =>
-    dockerImages.map(dockerImage => ({
-      ...dockerImage,
-      container: dockerImage.imageName,
-      status: selectContainerStatus(dockerImage.imageName)(rootState),
-    })),
-)
 
 export const selectContainersStatusesWithStats = createSelector(
   selectDockerImages,

--- a/applications/launchpad/gui-react/src/store/containers/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/containers/selectors.ts
@@ -43,7 +43,7 @@ export const selectContainerStatus: ContainerStatusSelector =
     if (!containerId) {
       return {
         id: '',
-        type: containerName,
+        containerName,
         error: typeError,
         running: false,
         pending,
@@ -58,8 +58,7 @@ export const selectContainerStatus: ContainerStatusSelector =
         (containerStatus.status !== SystemEventAction.Start &&
           containerStatus.status !== SystemEventAction.Destroy),
       running: containerStatus.status === SystemEventAction.Start,
-      // TODO rename
-      type: containerName,
+      containerName,
       error: containerStatus.error || typeError,
     }
   }

--- a/applications/launchpad/gui-react/src/store/containers/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/containers/selectors.ts
@@ -30,7 +30,7 @@ export const selectContainerStats = (containerId: string) => (r: RootState) =>
   r.containers.stats[containerId]
 
 type ContainerStatusSelector = (
-  c: string | Container,
+  c: ContainerName,
 ) => (r: RootState) => ContainerStatusDto
 export const selectContainerStatus: ContainerStatusSelector =
   containerName => rootState => {
@@ -61,13 +61,14 @@ export const selectContainerStatus: ContainerStatusSelector =
         (containerStatus.status !== SystemEventAction.Start &&
           containerStatus.status !== SystemEventAction.Destroy),
       running: containerStatus.status === SystemEventAction.Start,
+      // TODO rename
       type: containerName,
       error: containerStatus.error || typeError,
     }
   }
 
 type ContainerStatusSelectorWithStats = (
-  c: string | Container,
+  c: ContainerName,
 ) => (r: RootState) => ContainerStatusDtoWithStats
 export const selectContainerStatusWithStats: ContainerStatusSelectorWithStats =
   containerName => rootState => {

--- a/applications/launchpad/gui-react/src/store/containers/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/containers/selectors.ts
@@ -1,7 +1,8 @@
 import { createSelector } from '@reduxjs/toolkit'
 
 import { RootState } from '../'
-import { selectDockerImages } from '../dockerImages/selectors'
+import { ContainerName } from '../../types/general'
+import { selectDockerImages, selectRecipe } from '../dockerImages/selectors'
 
 import {
   ContainerStatusDto,
@@ -127,3 +128,24 @@ export const selectContainersStatusesWithStats = createSelector(
       ),
     })),
 )
+
+const selectContainerStatusesByRecipe =
+  (containerName: ContainerName) => (rootState: RootState) => {
+    const recipe = selectRecipe(containerName)(rootState)
+    return recipe.map(containerType =>
+      selectContainerStatus(containerType)(rootState),
+    )
+  }
+
+export const selectRecipeRunning = (containerName: ContainerName) =>
+  createSelector(
+    selectContainerStatusesByRecipe(containerName),
+    containers =>
+      containers.every(container => container.running) ||
+      containers.some(container => container.running && container.pending),
+  )
+
+export const selectRecipePending = (containerName: ContainerName) =>
+  createSelector(selectContainerStatusesByRecipe(containerName), containers =>
+    containers.some(container => container.pending),
+  )

--- a/applications/launchpad/gui-react/src/store/containers/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/containers/selectors.ts
@@ -13,7 +13,7 @@ import {
 
 export const selectState = (rootState: RootState) => rootState.containers
 
-export const selectContainer = (c: string | Container) => (r: RootState) => {
+export const selectContainer = (c: ContainerName) => (r: RootState) => {
   const containers = Object.entries(r.containers.containers).filter(
     ([, value]) => value.name === c,
   )
@@ -50,8 +50,9 @@ export const selectContainerStatus: ContainerStatusSelector =
       }
     }
 
+    const { name: _, ...containerStatusWithoutName } = containerStatus
     return {
-      ...containerStatus,
+      ...containerStatusWithoutName,
       id: containerId,
       pending:
         pending ||

--- a/applications/launchpad/gui-react/src/store/containers/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/containers/selectors.ts
@@ -41,7 +41,7 @@ export const selectContainerStatus: ContainerStatusSelector =
       rootState.containers.pending.includes(containerName) ||
       rootState.containers.pending.includes(containerId)
 
-    const typeError = undefined // rootState.containers.errors[containerType]
+    const typeError = rootState.containers.errors[containerName]
 
     if (!containerId) {
       return {

--- a/applications/launchpad/gui-react/src/store/containers/thunks.test.ts
+++ b/applications/launchpad/gui-react/src/store/containers/thunks.test.ts
@@ -74,7 +74,7 @@ describe('containers/thunks', () => {
       // when
       const action = addStats({
         containerId: expectedContainerId,
-        service: Container.Tor,
+        container: Container.Tor,
         stats: standardStats(),
       })
       const result = await action(() => null, getState, undefined)
@@ -109,7 +109,7 @@ describe('containers/thunks', () => {
       // when
       const action = addStats({
         containerId: 'someContainerId',
-        service: Container.Tor,
+        container: Container.Tor,
         stats: standardStats(),
       })
       const result = await action(() => null, getState, undefined)

--- a/applications/launchpad/gui-react/src/store/containers/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/containers/thunks.ts
@@ -211,7 +211,7 @@ export const stopRecipe = createAsyncThunk<
     )
 
     tail
-      .filter(tailPart => !containersRequiredByOtherServices.has(tailPart))
+      .filter(tailPart => !containersRequiredByOtherServices.has(tailPart.type))
       .forEach(tailPartToStop => thunkApi.dispatch(stop(tailPartToStop.id)))
   } catch (e) {
     return thunkApi.rejectWithValue(e)

--- a/applications/launchpad/gui-react/src/store/containers/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/containers/thunks.ts
@@ -211,7 +211,10 @@ export const stopRecipe = createAsyncThunk<
     )
 
     tail
-      .filter(tailPart => !containersRequiredByOtherServices.has(tailPart.type))
+      .filter(
+        tailPart =>
+          !containersRequiredByOtherServices.has(tailPart.containerName),
+      )
       .forEach(tailPartToStop => thunkApi.dispatch(stop(tailPartToStop.id)))
   } catch (e) {
     return thunkApi.rejectWithValue(e)

--- a/applications/launchpad/gui-react/src/store/containers/types.ts
+++ b/applications/launchpad/gui-react/src/store/containers/types.ts
@@ -4,8 +4,9 @@ import { ContainerName } from '../../types/general'
 
 export type ContainerId = string
 
-// TODO this should be removed from here and any usages should be got from backend
-// this refers to container_name in backend/src/docker/models.rs
+// WARNING - be careful about using this directly,
+// you should be using dockerImages.images from state if you work with docker images etc
+// this *couples fronted to backend* with container_name in backend/src/docker/models.rs
 export enum Container {
   Tor = 'tor',
   BaseNode = 'base_node',
@@ -54,7 +55,7 @@ export type ContainerStatus = {
 
 export type ContainerStatusDto = {
   id: ContainerId
-  type: string | Container
+  containerName: ContainerName
   running: boolean
   pending: boolean
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -71,7 +72,7 @@ export type ContainerStateFields = Pick<
 >
 
 export type ContainerStateFieldsWithIdAndType = ContainerStateFields &
-  Pick<ContainerStatusDto, 'id' | 'type'>
+  Pick<ContainerStatusDto, 'id' | 'containerName'>
 
 export type ContainersState = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/applications/launchpad/gui-react/src/store/containers/types.ts
+++ b/applications/launchpad/gui-react/src/store/containers/types.ts
@@ -4,6 +4,8 @@ import { ContainerName } from '../../types/general'
 
 export type ContainerId = string
 
+// TODO this should be removed from here and any usages should be got from backend
+// this refers to container_name in backend/src/docker/models.rs
 export enum Container {
   Tor = 'tor',
   BaseNode = 'base_node',

--- a/applications/launchpad/gui-react/src/store/containers/types.ts
+++ b/applications/launchpad/gui-react/src/store/containers/types.ts
@@ -1,5 +1,7 @@
 import type { UnlistenFn } from '@tauri-apps/api/event'
 
+import { ContainerName } from '../../types/general'
+
 export type ContainerId = string
 
 export enum Container {
@@ -71,8 +73,8 @@ export type ContainerStateFieldsWithIdAndType = ContainerStateFields &
 
 export type ContainersState = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  errors: Record<string | Container, any>
-  pending: Array<string | Container | ContainerId>
+  errors: Record<ContainerName, any>
+  pending: Array<ContainerName | ContainerId>
   containers: Record<ContainerId, ContainerStatus>
   stats: Record<ContainerId, ContainerStats>
 }

--- a/applications/launchpad/gui-react/src/store/containers/types.ts
+++ b/applications/launchpad/gui-react/src/store/containers/types.ts
@@ -43,14 +43,14 @@ export type SerializableContainerStats = Omit<ContainerStats, 'unsubscribe'>
 export type ContainerStatus = {
   status: SystemEventAction
   timestamp: number
-  type?: Container
+  name?: string
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error?: any
 }
 
 export type ContainerStatusDto = {
   id: ContainerId
-  type: Container
+  type: string | Container
   running: boolean
   pending: boolean
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -71,8 +71,8 @@ export type ContainerStateFieldsWithIdAndType = ContainerStateFields &
 
 export type ContainersState = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  errors: Record<Container, any>
-  pending: Array<Container | ContainerId>
+  errors: Record<string | Container, any>
+  pending: Array<string | Container | ContainerId>
   containers: Record<ContainerId, ContainerStatus>
   stats: Record<ContainerId, ContainerStats>
 }

--- a/applications/launchpad/gui-react/src/store/dockerImages/index.ts
+++ b/applications/launchpad/gui-react/src/store/dockerImages/index.ts
@@ -59,7 +59,6 @@ const slice = createSlice({
         }),
         {},
       )
-      console.debug(JSON.parse(JSON.stringify(state)))
     })
   },
 })

--- a/applications/launchpad/gui-react/src/store/dockerImages/index.ts
+++ b/applications/launchpad/gui-react/src/store/dockerImages/index.ts
@@ -8,6 +8,7 @@ import { getDockerImageList, pullImage } from './thunks'
 export const initialState: DockerImagesState = {
   loaded: false,
   images: [],
+  recipes: {},
 }
 
 const slice = createSlice({
@@ -49,7 +50,16 @@ const slice = createSlice({
     })
     builder.addCase(getDockerImageList.fulfilled, (state, action) => {
       state.loaded = true
-      state.images = action.payload
+      const { images, recipes } = action.payload
+      state.images = images
+      state.recipes = recipes.reduce(
+        (accu, current) => ({
+          ...accu,
+          [current[0]]: current,
+        }),
+        {},
+      )
+      console.debug(JSON.parse(JSON.stringify(state)))
     })
   },
 })

--- a/applications/launchpad/gui-react/src/store/dockerImages/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/dockerImages/selectors.ts
@@ -1,3 +1,4 @@
+import { ContainerName } from '../../types/general'
 import { RootState } from '../'
 
 export const selectDockerImages = ({ dockerImages }: RootState) =>
@@ -5,3 +6,8 @@ export const selectDockerImages = ({ dockerImages }: RootState) =>
 
 export const selectDockerImagesLoading = ({ dockerImages }: RootState) =>
   !dockerImages.loaded
+
+export const selectRecipe =
+  (container: ContainerName) =>
+  ({ dockerImages }: RootState) =>
+    dockerImages.recipes[container] || [container]

--- a/applications/launchpad/gui-react/src/store/dockerImages/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/dockerImages/thunks.ts
@@ -16,6 +16,8 @@ export const getDockerImageList = createAsyncThunk<
       settings: state.settings.serviceSettings,
     })
 
+    console.debug({ images })
+
     // TODO get status from backend after https://github.com/Altalogy/tari/issues/311
     return images.map(img => ({ ...img, latest: true }))
   } catch (e) {

--- a/applications/launchpad/gui-react/src/store/dockerImages/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/dockerImages/thunks.ts
@@ -19,7 +19,7 @@ export const getDockerImageList = createAsyncThunk<
     const { imageInfo, serviceRecipes } = await invoke<{
       imageInfo: DockerImage[]
       serviceRecipes: ServiceRecipe[]
-    }>('image_list', {
+    }>('image_info', {
       settings: state.settings.serviceSettings,
     })
 

--- a/applications/launchpad/gui-react/src/store/dockerImages/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/dockerImages/thunks.ts
@@ -2,24 +2,32 @@ import { createAsyncThunk } from '@reduxjs/toolkit'
 import { invoke } from '@tauri-apps/api/tauri'
 
 import { RootState } from '../'
-import { DockerImage, DockerImagePullStatus } from '../../types/general'
+import {
+  DockerImage,
+  DockerImagePullStatus,
+  ServiceRecipe,
+} from '../../types/general'
 
 export const getDockerImageList = createAsyncThunk<
-  DockerImage[],
+  { images: DockerImage[]; recipes: ServiceRecipe[] },
   void,
   { state: RootState }
 >('dockerImages/getDockerImageList', async (_, thunkApi) => {
   try {
     const state = thunkApi.getState()
 
-    const images = await invoke<DockerImage[]>('image_list', {
+    const { imageInfo, serviceRecipes } = await invoke<{
+      imageInfo: DockerImage[]
+      serviceRecipes: ServiceRecipe[]
+    }>('image_list', {
       settings: state.settings.serviceSettings,
     })
 
-    console.debug({ images })
-
     // TODO get status from backend after https://github.com/Altalogy/tari/issues/311
-    return images.map(img => ({ ...img, latest: true }))
+    return {
+      images: imageInfo.map(img => ({ ...img, latest: true })),
+      recipes: serviceRecipes,
+    }
   } catch (e) {
     return thunkApi.rejectWithValue(e)
   }

--- a/applications/launchpad/gui-react/src/store/dockerImages/types.ts
+++ b/applications/launchpad/gui-react/src/store/dockerImages/types.ts
@@ -1,6 +1,9 @@
-import { DockerImage } from '../../types/general'
+import { DockerImage, ContainerName, ServiceRecipe } from '../../types/general'
+
+export type Recipes = Record<ContainerName, ServiceRecipe>
 
 export type DockerImagesState = {
   loaded: boolean
   images: DockerImage[]
+  recipes: Recipes
 }

--- a/applications/launchpad/gui-react/src/store/mining/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/mining/selectors.ts
@@ -33,7 +33,7 @@ export const selectTariContainers = createSelector(
       }))
 
     return {
-      running: !containers.some(c => !c.running),
+      running: containers.every(c => c.running),
       pending: containers.some(c => c.pending),
       miningPending: sha3.pending,
       error: errors.length > 0 ? errors : undefined,

--- a/applications/launchpad/gui-react/src/store/mining/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/mining/selectors.ts
@@ -27,7 +27,7 @@ export const selectTariContainers = createSelector(
     const errors = containers
       .filter(c => c.error)
       .map(c => ({
-        type: c.type,
+        containerName: c.containerName,
         id: c.id,
         error: c.error,
       }))
@@ -70,7 +70,7 @@ export const selectMergedContainers = createSelector(
     const errors = containers
       .filter(c => c.error)
       .map(c => ({
-        type: c.type,
+        containerName: c.containerName,
         id: c.id,
         error: c.error,
       }))

--- a/applications/launchpad/gui-react/src/store/mining/thunks.test.ts
+++ b/applications/launchpad/gui-react/src/store/mining/thunks.test.ts
@@ -27,10 +27,15 @@ const shouldNotHaveCalledAnyActions = (
   })
 }
 
+const getMockedDispatch = () =>
+  jest.fn().mockReturnValue({
+    unwrap: () => Promise.resolve(),
+  })
+
 describe('starting node', () => {
   it('should throw an error if tari mining start is attempted with misconfigured wallet', async () => {
     // given
-    const dispatch = jest.fn()
+    const dispatch = getMockedDispatch()
     const getState = () =>
       ({
         wallet: {
@@ -65,7 +70,7 @@ describe('starting node', () => {
 
   it('should throw an error if merged mining start is attempted with misconfigured wallet', async () => {
     // given
-    const dispatch = jest.fn()
+    const dispatch = getMockedDispatch()
     const getState = () =>
       ({
         wallet: {
@@ -101,7 +106,7 @@ describe('starting node', () => {
 
   it('should throw an error if merged mining start is attempted with missing monero address', async () => {
     // given
-    const dispatch = jest.fn()
+    const dispatch = getMockedDispatch()
     const getState = () =>
       ({
         wallet: {
@@ -141,7 +146,7 @@ describe('start stop mining', () =>
     describe(miningNode, () => {
       it(`should not stop ${miningNode} mining by scheduled stop if it was started manually`, async () => {
         // given
-        const dispatch = jest.fn()
+        const dispatch = getMockedDispatch()
         const getState = () =>
           ({
             wallet: {
@@ -180,7 +185,7 @@ describe('start stop mining', () =>
 
       it(`should stop ${miningNode} mining manually after manual start`, async () => {
         // given
-        const dispatch = jest.fn()
+        const dispatch = getMockedDispatch()
         const getState = () =>
           ({
             wallet: {
@@ -225,7 +230,7 @@ describe('start stop mining', () =>
       it(`should stop ${miningNode} mining manually after scheduled start`, async () => {
         // given
         const scheduleId = 'someScheduleId'
-        const dispatch = jest.fn()
+        const dispatch = getMockedDispatch()
         const getState = () =>
           ({
             wallet: {
@@ -272,10 +277,7 @@ describe('start stop mining', () =>
       REASONS.forEach(previousSessionStopReason => {
         it(`should start ${miningNode} mining manually for stopReason: ${previousSessionStopReason}`, async () => {
           // given
-          const dispatch = jest.fn()
-          dispatch.mockReturnValue({
-            unwrap: () => Promise.resolve(),
-          })
+          const dispatch = getMockedDispatch()
           const getState = () =>
             ({
               wallet: {
@@ -324,10 +326,7 @@ describe('start stop mining', () =>
         it(`should start ${miningNode} mining on schedule for previous stop reason: ${previousSessionStopReason}`, async () => {
           // given
           const scheduleId = 'someScheduleId'
-          const dispatch = jest.fn()
-          dispatch.mockReturnValue({
-            unwrap: () => Promise.resolve(),
-          })
+          const dispatch = getMockedDispatch()
           const getState = () =>
             ({
               wallet: {
@@ -387,10 +386,7 @@ describe('start stop mining', () =>
       it(`should not start manually stopped scheduled ${miningNode} mining until next schedule`, async () => {
         // given
         const previousScheduleId = 'previousScheduleId'
-        const dispatch = jest.fn()
-        dispatch.mockReturnValue({
-          unwrap: () => Promise.resolve(),
-        })
+        const dispatch = getMockedDispatch()
         const getState = () =>
           ({
             wallet: {
@@ -434,10 +430,7 @@ describe('start stop mining', () =>
         // given
         const previousScheduleId = 'previousScheduleId'
         const nextScheduleId = 'nextScheduleId'
-        const dispatch = jest.fn()
-        dispatch.mockReturnValue({
-          unwrap: () => Promise.resolve(),
-        })
+        const dispatch = getMockedDispatch()
         const getState = () =>
           ({
             wallet: {
@@ -492,7 +485,7 @@ describe('start stop mining', () =>
 describe('Mining events', () => {
   it('should call addMined slice when data is correct', async () => {
     // given
-    const dispatch = jest.fn()
+    const dispatch = getMockedDispatch()
     const getState = () =>
       ({
         wallet: {
@@ -519,7 +512,7 @@ describe('Mining events', () => {
 
   it('should not call addMined action when transaction is already on the list', async () => {
     // given
-    const dispatch = jest.fn()
+    const dispatch = getMockedDispatch()
     const getState = () =>
       ({
         wallet: {

--- a/applications/launchpad/gui-react/src/store/mining/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/mining/thunks.ts
@@ -66,19 +66,19 @@ export const startMiningNode = createAsyncThunk<
 
     if (!torStatus.running && !torStatus.pending) {
       await thunkApi
-        .dispatch(containersActions.start({ service: Container.Tor }))
+        .dispatch(containersActions.start({ container: Container.Tor }))
         .unwrap()
     }
 
     if (!baseNodeStatus.running && !baseNodeStatus.pending) {
       await thunkApi
-        .dispatch(containersActions.start({ service: Container.BaseNode }))
+        .dispatch(containersActions.start({ container: Container.BaseNode }))
         .unwrap()
     }
 
     if (!walletStatus.running && !walletStatus.pending) {
       await thunkApi
-        .dispatch(containersActions.start({ service: Container.Wallet }))
+        .dispatch(containersActions.start({ container: Container.Wallet }))
         .unwrap()
     }
 
@@ -86,7 +86,7 @@ export const startMiningNode = createAsyncThunk<
       const minerStatus = selectContainerStatus(Container.SHA3Miner)(rootState)
       if (!minerStatus.running && !minerStatus.pending) {
         await thunkApi
-          .dispatch(containersActions.start({ service: Container.SHA3Miner }))
+          .dispatch(containersActions.start({ container: Container.SHA3Miner }))
           .unwrap()
         thunkApi.dispatch(
           miningActions.startNewSession({ node, reason, schedule }),
@@ -97,10 +97,10 @@ export const startMiningNode = createAsyncThunk<
     switch (node) {
       case 'merged':
         await thunkApi
-          .dispatch(containersActions.start({ service: Container.MMProxy }))
+          .dispatch(containersActions.start({ container: Container.MMProxy }))
           .unwrap()
         await thunkApi
-          .dispatch(containersActions.start({ service: Container.XMrig }))
+          .dispatch(containersActions.start({ container: Container.XMrig }))
           .unwrap()
         thunkApi.dispatch(
           miningActions.startNewSession({ node, reason, schedule }),

--- a/applications/launchpad/gui-react/src/store/wallet/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/wallet/selectors.ts
@@ -1,8 +1,9 @@
-import { createSelector } from '@reduxjs/toolkit'
-
 import { RootState } from '../'
 import { Container } from '../containers/types'
-import { selectContainerStatus } from '../containers/selectors'
+import {
+  selectRecipePending,
+  selectRecipeRunning,
+} from '../containers/selectors'
 
 import { WalletSetupRequired } from './types'
 
@@ -27,18 +28,6 @@ export const selectTariBalance = (state: RootState) => state.wallet.tari
 export const selectWalletSetupRequired = (state: RootState) =>
   !state.wallet.address ? WalletSetupRequired.MissingWalletAddress : undefined
 
-const requiredContainers = [Container.Tor, Container.BaseNode, Container.Wallet]
-export const selectContainerStatuses = (rootState: RootState) =>
-  requiredContainers.map(containerType =>
-    selectContainerStatus(containerType)(rootState),
-  )
-export const selectIsPending = createSelector(
-  selectContainerStatuses,
-  containers => containers.some(container => container.pending),
-)
-export const selectIsRunning = createSelector(
-  selectContainerStatuses,
-  containers =>
-    containers.every(container => container.running) ||
-    containers.some(container => container.running && container.pending),
-)
+export const selectIsPending = selectRecipePending(Container.Wallet)
+
+export const selectIsRunning = selectRecipeRunning(Container.Wallet)

--- a/applications/launchpad/gui-react/src/store/wallet/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/wallet/thunks.ts
@@ -33,7 +33,7 @@ export const unlockWallet = createAsyncThunk<
       await thunkApi
         .dispatch(
           containersActions.start({
-            service: Container.Tor,
+            container: Container.Tor,
           }),
         )
         .unwrap()
@@ -45,7 +45,7 @@ export const unlockWallet = createAsyncThunk<
       await thunkApi
         .dispatch(
           containersActions.start({
-            service: Container.BaseNode,
+            container: Container.BaseNode,
           }),
         )
         .unwrap()
@@ -56,7 +56,7 @@ export const unlockWallet = createAsyncThunk<
       await thunkApi
         .dispatch(
           containersActions.start({
-            service: Container.Wallet,
+            container: Container.Wallet,
             serviceSettings: { walletPassword },
           }),
         )

--- a/applications/launchpad/gui-react/src/types/general.ts
+++ b/applications/launchpad/gui-react/src/types/general.ts
@@ -44,6 +44,7 @@ export enum DockerImagePullStatus {
 }
 
 export type ContainerName = string
+export type ServiceRecipe = ContainerName[]
 export type DockerImage = {
   imageName: string
   displayName: string

--- a/applications/launchpad/gui-react/src/types/general.ts
+++ b/applications/launchpad/gui-react/src/types/general.ts
@@ -47,6 +47,7 @@ export type DockerImage = {
   imageName: string
   displayName: string
   dockerImage: string
+  containerName: string
   latest: boolean
   pending?: boolean
   error?: string

--- a/applications/launchpad/gui-react/src/types/general.ts
+++ b/applications/launchpad/gui-react/src/types/general.ts
@@ -43,11 +43,12 @@ export enum DockerImagePullStatus {
   Ready = 'ready',
 }
 
+export type ContainerName = string
 export type DockerImage = {
   imageName: string
   displayName: string
   dockerImage: string
-  containerName: string
+  containerName: ContainerName
   latest: boolean
   pending?: boolean
   error?: string


### PR DESCRIPTION
Description
---

- [x] make containers list in performance containers list to use docker images returned from backend
- [x] remake docker container state management to user containerName returned by backend instead of hardcoded FE type
- [x] move information about service dependencies to backend as 'recipes'
- [x] cleanup services that lose their required parts after service stop

Motivation and Context
---

#292 

How Has This Been Tested?
---

![cleanup](https://user-images.githubusercontent.com/9142942/176195676-37c29a1b-1238-45e2-803e-6fb623a71694.gif)
