### PR TITLE
feat: base node qr code

### DIFF
--- a/applications/launchpad/gui-react/package.json
+++ b/applications/launchpad/gui-react/package.json
@@ -22,6 +22,7 @@
     "react-css-transition-replace": "^4.0.5",
     "react-dom": ">=18.0.0",
     "react-hook-form": "^7.30.0",
+    "react-qr-code": "^2.0.7",
     "react-redux": "^8.0.0",
     "react-scripts": "5.0.0",
     "react-spring": "^9.4.5-beta.1",

--- a/applications/launchpad/gui-react/src/components/Button/index.tsx
+++ b/applications/launchpad/gui-react/src/components/Button/index.tsx
@@ -25,6 +25,7 @@ import { ButtonProps } from './types'
  * @param {ReactNode} [rightIcon] - element rendered on right side of the button
  * @param {boolean} [autosizeIcons='true'] - by default, it resizes any svg element set as leftIcon or rightIcon to a given dimensions (16x16px)
  * @param {boolean} [loading] - displays the loader
+ * @param {boolean} [fullWidth] - render with width = 100%
  * @param {() => void} [onClick] - on button click
  * @param {string} [testId] - react test id
  *
@@ -52,6 +53,7 @@ const Button = ({
   autosizeIcons = true,
   onClick,
   loading,
+  fullWidth,
   testId = 'button-cmp',
 }: ButtonProps) => {
   let btnText = children
@@ -128,6 +130,7 @@ const Button = ({
           target='_blank'
           variant={variant}
           data-testid={testId}
+          $fullWidth={fullWidth}
         >
           {btnContent}
         </StyledLinkLikeButton>
@@ -156,6 +159,7 @@ const Button = ({
       style={style}
       variant={variant}
       data-testid={testId}
+      $fullWidth={fullWidth}
     >
       {btnContent}
     </StyledButton>

--- a/applications/launchpad/gui-react/src/components/Button/styles.ts
+++ b/applications/launchpad/gui-react/src/components/Button/styles.ts
@@ -22,10 +22,14 @@ const getButtonBackgroundColor = ({
   }
 }
 
-const ButtonCSS = css`
+const ButtonCSS = css<
+  { $fullWidth?: boolean } & Pick<ButtonProps, 'variant' | 'type' | 'disabled'>
+>`
 display: flex;
 position: relative;
-justify-content: space-between;
+${({ $fullWidth }) => $fullWidth && 'width: 100%;'}
+justify-content: ${({ $fullWidth }) =>
+  $fullWidth ? 'center' : 'space-between'};
 align-items: center;
 column-gap: 0.25em;
 margin: 0;
@@ -98,13 +102,13 @@ text-decoration: none;
 `
 
 export const StyledButton = styled.button<
-  Pick<ButtonProps, 'variant' | 'type'>
+  { $fullWidth?: boolean } & Pick<ButtonProps, 'variant' | 'type' | 'disabled'>
 >`
   ${ButtonCSS}
 `
 
 export const StyledLinkLikeButton = styled.a<
-  Pick<ButtonProps, 'variant' | 'type'>
+  { $fullWidth?: boolean } & Pick<ButtonProps, 'variant' | 'type' | 'disabled'>
 >`
   ${ButtonCSS}
 `

--- a/applications/launchpad/gui-react/src/components/Button/types.ts
+++ b/applications/launchpad/gui-react/src/components/Button/types.ts
@@ -24,5 +24,6 @@ export interface ButtonProps {
   autosizeIcons?: boolean
   onClick?: () => void
   loading?: boolean
+  fullWidth?: boolean
   testId?: string
 }

--- a/applications/launchpad/gui-react/src/containers/BaseNodeContainer/BaseNode.tsx
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeContainer/BaseNode.tsx
@@ -13,6 +13,8 @@ import SvgSetting2 from '../../styles/Icons/Setting2'
 import { useAppDispatch } from '../../store/hooks'
 import { actions as settingsActions } from '../../store/settings'
 import { Settings } from '../../store/settings/types'
+import BaseNodeQRModal from '../BaseNodeQRModal'
+import { useState } from 'react'
 
 const BaseNode = ({
   running,
@@ -24,6 +26,8 @@ const BaseNode = ({
 }: BaseNodeProps) => {
   const theme = useTheme()
   const dispatch = useAppDispatch()
+
+  const [openQRModal, setOpenQRModal] = useState(false)
 
   return (
     <>
@@ -90,6 +94,31 @@ const BaseNode = ({
           </Button>
         )}
       </Box>
+
+      <Box
+        border={false}
+        style={{ background: theme.backgroundSecondary, marginTop: 0 }}
+      >
+        <Tag>{t.common.adjectives.recommended}</Tag>
+        <Text style={{ marginTop: theme.spacingVertical(1.2) }}>
+          <Button variant='button-in-text' onClick={() => setOpenQRModal(true)}>
+            {t.baseNode.aurora.connectYourAurora}
+          </Button>{' '}
+          <Text as='span'>{t.baseNode.aurora.withBaseNode}</Text>
+        </Text>
+        <Text
+          type='smallMedium'
+          style={{ marginTop: theme.spacingVertical(0.67) }}
+          color={theme.secondary}
+        >
+          {t.baseNode.aurora.description}
+        </Text>
+      </Box>
+      <BaseNodeQRModal
+        open={openQRModal}
+        onClose={() => setOpenQRModal(false)}
+      />
+
       <Button
         autosizeIcons={false}
         variant='text'
@@ -97,6 +126,7 @@ const BaseNode = ({
         style={{
           paddingLeft: 0,
           width: '199px',
+          color: theme.primary,
         }}
         onClick={() =>
           dispatch(settingsActions.open({ toOpen: Settings.BaseNode }))

--- a/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/BaseNodeQRModal.test.tsx
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/BaseNodeQRModal.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { ThemeProvider } from 'styled-components'
+
+import themes from '../../styles/themes'
+
+import BaseNodeQRModal from '.'
+
+describe('BaseNodeQRModal', () => {
+  it('should render modal with the QR Code without crashing', () => {
+    const onCloseFn = jest.fn()
+    render(
+      <ThemeProvider theme={themes.light}>
+        <BaseNodeQRModal open onClose={onCloseFn} />
+      </ThemeProvider>,
+    )
+
+    const el = screen.getByTestId('base-node-qr-code')
+    expect(el).toBeInTheDocument()
+  })
+})

--- a/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/index.tsx
@@ -1,0 +1,83 @@
+import QRCode from 'react-qr-code'
+import Button from '../../components/Button'
+
+import Modal from '../../components/Modal'
+import Text from '../../components/Text'
+
+import t from '../../locales'
+import {
+  ModalContainer,
+  Content,
+  CtaButton,
+  Steps,
+  Instructions,
+  QRContainer,
+} from './styles'
+
+import { BaseNodeQRModalProps } from './types'
+
+/**
+ * @TODO Replace with real data
+ */
+const QRContent =
+  'tari://dibbler/base_nodes/add?name=00000000000000000000000000&peer=::/onion3/0000000000000000000000000000000000000000000000000000000000000000:00000'
+
+/**
+ * The modal rendering the Base Node address as QR code.
+ * @param {boolean} open - show modal
+ * @param {() => void} onClose - on modal close
+ */
+const BaseNodeQRModal = ({ open, onClose }: BaseNodeQRModalProps) => {
+  return (
+    <Modal open={open} onClose={onClose} size='small'>
+      <ModalContainer>
+        <Content>
+          <Text as='h2' type='subheader'>
+            {t.baseNode.qrModal.heading}
+          </Text>
+          <Instructions>
+            <Text type='smallMedium'>{t.baseNode.qrModal.description}</Text>
+            <Steps>
+              <li>
+                <Text as='span' type='smallMedium'>
+                  {t.baseNode.qrModal.step1}
+                </Text>
+              </li>
+              <li>
+                <Text as='span' type='smallMedium'>
+                  {t.baseNode.qrModal.step2}
+                </Text>
+              </li>
+              <li>
+                <Text as='span' type='smallMedium'>
+                  {t.baseNode.qrModal.step3}
+                </Text>
+              </li>
+              <li>
+                <Text as='span' type='smallMedium'>
+                  {t.baseNode.qrModal.step4}
+                </Text>
+              </li>
+            </Steps>
+          </Instructions>
+
+          <QRContainer>
+            <QRCode
+              value={QRContent}
+              level='H'
+              size={220}
+              data-testid='base-node-qr-code'
+            />
+          </QRContainer>
+        </Content>
+        <CtaButton>
+          <Button onClick={onClose} fullWidth>
+            {t.baseNode.qrModal.submitBtn}
+          </Button>
+        </CtaButton>
+      </ModalContainer>
+    </Modal>
+  )
+}
+
+export default BaseNodeQRModal

--- a/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/styles.ts
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/styles.ts
@@ -1,0 +1,34 @@
+import styled from 'styled-components'
+
+export const ModalContainer = styled.div`
+  padding: ${({ theme }) => theme.spacing(1.7)};
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  box-sizing: border-box;
+  overflow: auto;
+`
+
+export const Content = styled.div`
+  flex: 1;
+`
+
+export const CtaButton = styled.div`
+  margin-top: ${({ theme }) => theme.spacingVertical(3)};
+`
+
+export const Instructions = styled.div`
+  margin-top: ${({ theme }) => theme.spacingVertical(2.2)};
+  margin-bottom: ${({ theme }) => theme.spacingVertical(3)};
+`
+
+export const Steps = styled.ol`
+  margin-top: ${({ theme }) => theme.spacingVertical(1.6)};
+  padding-left: ${({ theme }) => theme.spacingVertical(2)};
+`
+
+export const QRContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`

--- a/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/types.ts
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/types.ts
@@ -1,0 +1,4 @@
+export interface BaseNodeQRModalProps {
+  open: boolean
+  onClose: () => void
+}

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/BaseNodeSettings.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/BaseNodeSettings.tsx
@@ -22,9 +22,11 @@ import MessagesConfig from '../../../config/helpMessagesConfig'
 const BaseNodeSettings = ({
   control,
   network,
+  onBaseNodeConnectClick,
 }: {
   control: Control<SettingsInputs>
   network: Network
+  onBaseNodeConnectClick: () => void
 }) => {
   const theme = useTheme()
   const dispatch = useAppDispatch()
@@ -80,6 +82,7 @@ const BaseNodeSettings = ({
             <Button
               variant='button-in-text'
               style={{ color: theme.onTextLight, fontSize: '14px' }}
+              onClick={onBaseNodeConnectClick}
             >
               <Text type='smallMedium'>{t.common.verbs.connect}</Text>
             </Button>{' '}

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/index.tsx
@@ -7,12 +7,20 @@ import { SettingsInputs } from '../types'
 
 const BaseNodeSettingsContainer = ({
   control,
+  onBaseNodeConnectClick,
 }: {
   control: Control<SettingsInputs>
+  onBaseNodeConnectClick: () => void
 }) => {
   const { network } = useAppSelector(selectBaseNodeState)
 
-  return <BaseNodeSettings control={control} network={network} />
+  return (
+    <BaseNodeSettings
+      control={control}
+      network={network}
+      onBaseNodeConnectClick={onBaseNodeConnectClick}
+    />
+  )
 }
 
 export default BaseNodeSettingsContainer

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
@@ -34,6 +34,7 @@ import {
 } from './types'
 import MoneroAuthentication from './MiningSettings/MoneroAuthentication'
 import { useTheme } from 'styled-components'
+import BaseNodeQRModal from '../BaseNodeQRModal'
 
 const renderSettings = (
   settings: Settings,
@@ -53,7 +54,12 @@ const renderSettings = (
         />
       )
     case Settings.BaseNode:
-      return <BaseNodeSettings control={props.control} />
+      return (
+        <BaseNodeSettings
+          control={props.control}
+          onBaseNodeConnectClick={props.onBaseNodeConnectClick}
+        />
+      )
     case Settings.Docker:
       return (
         <DockerSettings
@@ -85,6 +91,8 @@ const SettingsComponent = ({
   discardChanges,
   openMiningAuthForm,
   setOpenMiningAuthForm,
+  openBaseNodeConnect,
+  setOpenBaseNodeConnect,
   currentTheme,
   changeTheme,
 }: SettingsComponentProps) => {
@@ -106,6 +114,13 @@ const SettingsComponent = ({
           close={() => setOpenMiningAuthForm(false)}
         />
       </Modal>
+    )
+  }
+
+  // Render Base Node QR code
+  if (openBaseNodeConnect) {
+    return (
+      <BaseNodeQRModal open onClose={() => setOpenBaseNodeConnect(false)} />
     )
   }
 
@@ -159,6 +174,7 @@ const SettingsComponent = ({
               values,
               setValue,
               setOpenMiningAuthForm,
+              onBaseNodeConnectClick: () => setOpenBaseNodeConnect(true),
             })}
           </MainContent>
         </MainContentContainer>

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/index.tsx
@@ -28,6 +28,7 @@ const SettingsContainer = () => {
   const currentTheme = useAppSelector(selectTheme)
 
   const [openMiningAuthForm, setOpenMiningAuthForm] = useState(false)
+  const [openBaseNodeConnect, setOpenBaseNodeConnect] = useState(false)
   const [confirmCancel, setConfirmCancel] = useState(false)
 
   const defaultValues = useMemo(
@@ -111,6 +112,8 @@ const SettingsContainer = () => {
       discardChanges={closeAndDiscard}
       openMiningAuthForm={openMiningAuthForm}
       setOpenMiningAuthForm={setOpenMiningAuthForm}
+      openBaseNodeConnect={openBaseNodeConnect}
+      setOpenBaseNodeConnect={setOpenBaseNodeConnect}
       currentTheme={currentTheme}
       changeTheme={changeTheme}
     />

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/types.ts
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/types.ts
@@ -10,6 +10,7 @@ export type SettingsProps = {
   values: SettingsInputs
   setValue: UseFormSetValue<SettingsInputs>
   setOpenMiningAuthForm: (value: boolean) => void
+  onBaseNodeConnectClick: () => void
 }
 
 export interface SettingsInputs {
@@ -56,6 +57,8 @@ export type SettingsComponentProps = {
   discardChanges: () => void
   openMiningAuthForm: boolean
   setOpenMiningAuthForm: (value: boolean) => void
+  openBaseNodeConnect: boolean
+  setOpenBaseNodeConnect: (value: boolean) => void
   currentTheme: ThemeType
   changeTheme: (theme: ThemeType) => void
 }

--- a/applications/launchpad/gui-react/src/locales/baseNode.ts
+++ b/applications/launchpad/gui-react/src/locales/baseNode.ts
@@ -41,6 +41,21 @@ const translations = {
   viewActions: {
     baseNodeSettings: 'Base Node settings',
   },
+  qrModal: {
+    heading: 'Connect your Aurora app',
+    description: 'Open Aurora app on your smartphone.',
+    step1: 'Go to Settings',
+    step2: 'Choose: Connect to Tari Launchpad Base Node',
+    step3: 'Scan the QR code below',
+    step4: 'Then follow the directions in the Aurora app',
+    submitBtn: 'Got it!',
+  },
+  aurora: {
+    connectYourAurora: 'Connect your Aurora app',
+    withBaseNode: 'with the Base Node',
+    description:
+      'If you have an Aurora Wallet on your smartphone, you can increase its security by connecting to the Tari Base Node.',
+  },
 }
 
 export default translations

--- a/applications/launchpad/gui-react/src/locales/common.ts
+++ b/applications/launchpad/gui-react/src/locales/common.ts
@@ -54,6 +54,7 @@ const translations: { [key: string]: { [key: string]: string } } = {
     running: 'Running',
     paused: 'Paused',
     copied: 'Copied',
+    recommended: 'Recommended',
   },
   conjunctions: {
     or: 'or',

--- a/applications/launchpad/gui-react/src/store/app/index.ts
+++ b/applications/launchpad/gui-react/src/store/app/index.ts
@@ -82,7 +82,7 @@ export const {
   setOnboardingComplete,
   setOnboardingCheckpoint,
 } = appSlice.actions
-export * from './thunks'
+export { init } from './thunks'
 
 const reducer = appSlice.reducer
 export default reducer

--- a/applications/launchpad/gui-react/yarn.lock
+++ b/applications/launchpad/gui-react/yarn.lock
@@ -7789,6 +7789,11 @@ q@^1.1.2:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
 
+qr.js@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/qr.js/-/qr.js-0.0.0.tgz#cace86386f59a0db8050fa90d9b6b0e88a1e364f"
+  integrity sha512-c4iYnWb+k2E+vYpRimHqSu575b1/wKl4XFeJGpFmrJQz5I88v9aY2czh7s0w36srfCM1sXgC/xpoJz5dJfq+OQ==
+
 qs@6.10.3:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
@@ -7936,6 +7941,14 @@ react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
+
+react-qr-code@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/react-qr-code/-/react-qr-code-2.0.7.tgz#508304e031e82426a044f5e9490aca87d7c3de38"
+  integrity sha512-NpknL80p7dWbLdHfBSIxQIqLCu3+kBlyzYD692rO0UnVwfCSziIxc1xn/p3JhPEv1RV1lRD8j0w+hR3L7tawTQ==
+  dependencies:
+    prop-types "^15.7.2"
+    qr.js "0.0.0"
 
 react-redux@^8.0.0:
   version "8.0.2"
@@ -8998,7 +9011,7 @@ tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   version "0.1.1"
   resolved "https://codeload.github.com/tauri-apps/tauri-plugin-sql/tar.gz/d8ea61f2cbe2dfc9bf0947bab87b1547dcc945d4"
   dependencies:
-    "@tauri-apps/api" "1.0.0"
+    "@tauri-apps/api" "1.0.0-rc.5"
     tslib "2.4.0"
 
 temp-dir@^2.0.0:


### PR DESCRIPTION
Description
---

- [x] Create the Modal containing QR code
- [x] Add modal to the Base Node page
- [x] Add modal to the Base Node tab in Settings modal
- [ ] Embed real Base Node address in the QR code (_the QR content is hard-coded with `QRContent` in BaseNodeQRModal container for now)_ - TODO: #340 

Side improvements:
- [x] add `fullWidth` prop to the `Button` component. If `true`, the button expands to all available width.

Motivation and Context
---

#27

How Has This Been Tested?
---

![image](https://user-images.githubusercontent.com/11715931/176311270-b5bb56df-f609-45f2-8e28-2672580fdc64.png)

