### PR TITLE
fix: input with label baseline issue

### DIFF
--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/BaseNodeSettings.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/BaseNodeSettings.tsx
@@ -42,7 +42,7 @@ const BaseNodeSettings = ({
         rules={{ required: true, minLength: 1 }}
         render={({ field }) => (
           <SelectRow>
-            <Label>{t.baseNode.tari_network_label}</Label>
+            <Label $noMargin>{t.baseNode.tari_network_label}</Label>
             <div style={{ width: '50%' }}>
               <Select
                 value={networkOptions.find(
@@ -66,7 +66,7 @@ const BaseNodeSettings = ({
         rules={{ required: true, minLength: 1 }}
         render={({ field }) => (
           <InputRow>
-            <Label>{t.baseNode.settings.rootFolder}</Label>
+            <Label $noMargin>{t.baseNode.settings.rootFolder}</Label>
             <Input
               onChange={field.onChange}
               value={field?.value?.toString() || ''}

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/styles.ts
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/styles.ts
@@ -3,14 +3,14 @@ import styled from 'styled-components'
 export const SelectRow = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
   margin-top: ${({ theme }) => theme.spacingVertical(2.5)};
 `
 
 export const InputRow = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
 `
 
 export const ConnectionRow = styled.div`

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/DockerSettings/DockerSettings.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/DockerSettings/DockerSettings.tsx
@@ -42,11 +42,11 @@ const DockerSettings = ({
         style={{
           display: 'flex',
           justifyContent: 'space-between',
-          alignItems: 'baseline',
+          alignItems: 'center',
           margin: `${theme.spacingVertical(0.5)} 0`,
         }}
       >
-        <Label>{t.docker.settings.tagLabel}</Label>
+        <Label $noMargin>{t.docker.settings.tagLabel}</Label>
         <Controller
           name='docker.tag'
           control={control}
@@ -66,11 +66,11 @@ const DockerSettings = ({
         style={{
           display: 'flex',
           justifyContent: 'space-between',
-          alignItems: 'baseline',
+          alignItems: 'center',
           margin: `${theme.spacingVertical(0.5)} 0`,
         }}
       >
-        <Label>{t.docker.settings.registryLabel}</Label>
+        <Label $noMargin>{t.docker.settings.registryLabel}</Label>
         <Controller
           name='docker.registry'
           control={control}


### PR DESCRIPTION
Description
---

This is the fix to issue described below.


Motivation and Context
---

Clearing the input disrupts the layout of label and input:

![inputs-baseline-1](https://user-images.githubusercontent.com/11715931/176382802-7299fe14-cf9e-4e51-913a-d56918701e45.gif)

How Has This Been Tested?
---

![inputs-issue-2](https://user-images.githubusercontent.com/11715931/176382821-476a2d10-87ff-45e7-afa6-6c38632dcabb.gif)

