### PR TITLE
feat: add directory picker dialog to root folder input

### DIFF
--- a/applications/launchpad/gui-react/src/components/Inputs/Input/index.tsx
+++ b/applications/launchpad/gui-react/src/components/Inputs/Input/index.tsx
@@ -101,22 +101,24 @@ const Input = (
           style={style}
           ref={ref}
         />
-        <IconUnitsContainer $iconWrapperWidth={iconWrapperWidth}>
-          {inputIcon && (
-            <IconWrapper
-              onClick={disabled ? undefined : onIconClick}
-              data-testid='icon-test'
-              ref={iconsRef}
-            >
-              {inputIcon}
-            </IconWrapper>
-          )}{' '}
-          {inputUnits && (
-            <UnitsText type='smallMedium' data-testid='units-test'>
-              {inputUnits}
-            </UnitsText>
-          )}
-        </IconUnitsContainer>
+        {(inputIcon || inputUnits) && (
+          <IconUnitsContainer $iconWrapperWidth={iconWrapperWidth}>
+            {inputIcon && (
+              <IconWrapper
+                onClick={disabled ? undefined : onIconClick}
+                data-testid='icon-test'
+                ref={iconsRef}
+              >
+                {inputIcon}
+              </IconWrapper>
+            )}{' '}
+            {inputUnits && (
+              <UnitsText type='smallMedium' data-testid='units-test'>
+                {inputUnits}
+              </UnitsText>
+            )}
+          </IconUnitsContainer>
+        )}
       </InputContainer>
       {error && (
         <Text

--- a/applications/launchpad/gui-react/src/components/Inputs/Input/index.tsx
+++ b/applications/launchpad/gui-react/src/components/Inputs/Input/index.tsx
@@ -53,6 +53,7 @@ const Input = (
     containerStyle,
     inverted,
     withError = true,
+    onClick,
   }: InputProps,
   ref?: React.ForwardedRef<HTMLInputElement>,
 ) => {
@@ -81,6 +82,7 @@ const Input = (
         </Label>
       )}
       <InputContainer
+        onClick={onClick}
         disabled={disabled}
         $error={Boolean(error)}
         $withError={withError}

--- a/applications/launchpad/gui-react/src/components/Inputs/Input/types.ts
+++ b/applications/launchpad/gui-react/src/components/Inputs/Input/types.ts
@@ -18,4 +18,5 @@ export interface InputProps
   containerStyle?: CSSProperties
   inverted?: boolean
   withError?: boolean
+  onClick?: () => void
 }

--- a/applications/launchpad/gui-react/src/containers/BaseNodeContainer/BaseNode.tsx
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeContainer/BaseNode.tsx
@@ -118,22 +118,21 @@ const BaseNode = ({
         open={openQRModal}
         onClose={() => setOpenQRModal(false)}
       />
-
-      <Button
-        autosizeIcons={false}
-        variant='text'
-        leftIcon={<SvgSetting2 width='1.5rem' height='1.5rem' />}
-        style={{
-          paddingLeft: 0,
-          width: '199px',
-          color: theme.primary,
-        }}
-        onClick={() =>
-          dispatch(settingsActions.open({ toOpen: Settings.BaseNode }))
-        }
-      >
-        {t.baseNode.viewActions.baseNodeSettings}
-      </Button>
+      <div style={{ width: '100%' }}>
+        <Button
+          autosizeIcons={false}
+          variant='text'
+          leftIcon={<SvgSetting2 width='1.5rem' height='1.5rem' />}
+          style={{
+            paddingLeft: 0,
+          }}
+          onClick={() =>
+            dispatch(settingsActions.open({ toOpen: Settings.BaseNode }))
+          }
+        >
+          {t.baseNode.viewActions.baseNodeSettings}
+        </Button>
+      </div>
     </>
   )
 }

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/BaseNodeSettings.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/BaseNodeSettings.tsx
@@ -33,16 +33,18 @@ const BaseNodeSettings = ({
 }) => {
   const theme = useTheme()
   const dispatch = useAppDispatch()
-  const selectDirectory = useCallback(async () => {
+  const selectDirectory = useCallback(async (lastPath?: string) => {
     const selectedFolder = await open({
       directory: true,
-      defaultPath: await appDir(),
+      defaultPath: lastPath || (await appDir()),
     })
 
     if (selectedFolder === null) {
       return
     } else if (typeof selectedFolder === 'string') {
-      setValue('baseNode.rootFolder', selectedFolder, { shouldDirty: true })
+      setValue('baseNode.rootFolder', selectedFolder, {
+        shouldDirty: true,
+      })
     }
   }, [])
   return (
@@ -81,7 +83,7 @@ const BaseNodeSettings = ({
           <InputRow>
             <Label $noMargin>{t.baseNode.settings.rootFolder}</Label>
             <Input
-              onClick={() => selectDirectory()}
+              onClick={() => selectDirectory(field.value)}
               onChange={field.onChange}
               value={field?.value?.toString() || ''}
               containerStyle={{ width: '50%' }}

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/BaseNodeSettings.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/BaseNodeSettings.tsx
@@ -1,4 +1,7 @@
-import { Controller, Control } from 'react-hook-form'
+import { useCallback } from 'react'
+import { Controller, Control, UseFormSetValue } from 'react-hook-form'
+import { open } from '@tauri-apps/api/dialog'
+import { appDir } from '@tauri-apps/api/path'
 
 import Select from '../../../components/Select'
 import Text from '../../../components/Text'
@@ -22,12 +25,26 @@ import MessagesConfig from '../../../config/helpMessagesConfig'
 const BaseNodeSettings = ({
   control,
   onBaseNodeConnectClick,
+  setValue,
 }: {
   control: Control<SettingsInputs>
   onBaseNodeConnectClick: () => void
+  setValue: UseFormSetValue<SettingsInputs>
 }) => {
   const theme = useTheme()
   const dispatch = useAppDispatch()
+  const selectDirectory = useCallback(async () => {
+    const selectedFolder = await open({
+      directory: true,
+      defaultPath: await appDir(),
+    })
+
+    if (selectedFolder === null) {
+      return
+    } else if (typeof selectedFolder === 'string') {
+      setValue('baseNode.rootFolder', selectedFolder, { shouldDirty: true })
+    }
+  }, [])
   return (
     <>
       <Text type='subheader' as='h2'>
@@ -64,6 +81,7 @@ const BaseNodeSettings = ({
           <InputRow>
             <Label $noMargin>{t.baseNode.settings.rootFolder}</Label>
             <Input
+              onClick={() => selectDirectory()}
               onChange={field.onChange}
               value={field?.value?.toString() || ''}
               containerStyle={{ width: '50%' }}

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/index.tsx
@@ -1,18 +1,21 @@
 import BaseNodeSettings from './BaseNodeSettings'
-import { Control } from 'react-hook-form'
+import { Control, UseFormSetValue } from 'react-hook-form'
 import { SettingsInputs } from '../types'
 
 const BaseNodeSettingsContainer = ({
   control,
   onBaseNodeConnectClick,
+  setValue,
 }: {
   control: Control<SettingsInputs>
   onBaseNodeConnectClick: () => void
+  setValue: UseFormSetValue<SettingsInputs>
 }) => {
   return (
     <BaseNodeSettings
       control={control}
       onBaseNodeConnectClick={onBaseNodeConnectClick}
+      setValue={setValue}
     />
   )
 }

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/SettingsComponent.tsx
@@ -58,6 +58,7 @@ const renderSettings = (
         <BaseNodeSettings
           control={props.control}
           onBaseNodeConnectClick={props.onBaseNodeConnectClick}
+          setValue={props.setValue}
         />
       )
     case Settings.Docker:
@@ -97,7 +98,6 @@ const SettingsComponent = ({
   changeTheme,
 }: SettingsComponentProps) => {
   const theme = useTheme()
-
   // Render Monero Authentication form if open:
   if (openMiningAuthForm) {
     return (


### PR DESCRIPTION
Description
---
- [x] Add Tauri dialog API directory picker to root folder input field
- [x] Fix settings button styling on `BaseNode`  tab

Motivation and Context
---
#343 

How Has This Been Tested?
---

https://user-images.githubusercontent.com/69508715/176632727-e9823ddd-2b1e-4509-a1bc-a922bd3dfa41.mov

With updated `defaultPath` prop:

https://user-images.githubusercontent.com/69508715/176651416-523c6692-cfc3-4c56-ad2f-0a272759be88.mov


