### PR TITLE
feat: upgrade tauri version 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3437,6 +3437,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4831,6 +4840,20 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "plist"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
+dependencies = [
+ "base64 0.13.0",
+ "indexmap",
+ "line-wrap",
+ "serde",
+ "time 0.3.11",
+ "xml-rs",
+]
 
 [[package]]
 name = "plotters"
@@ -6440,9 +6463,9 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bfe4c782f0543f667ee3b732d026b2f1c64af39cd52e726dec1ea1f2d8f6b80"
+checksum = "1e394212ba69118794d1b66e1c3a9752f483d228e8ac0c2820f6324d72b5332e"
 dependencies = [
  "bitflags 1.3.2",
  "cairo-rs",
@@ -6477,24 +6500,11 @@ dependencies = [
  "raw-window-handle",
  "scopeguard",
  "serde",
- "tao-core-video-sys",
  "unicode-segmentation",
  "uuid 0.8.2",
  "windows 0.37.0",
  "windows-implement",
  "x11-dl",
-]
-
-[[package]]
-name = "tao-core-video-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271450eb289cb4d8d0720c6ce70c72c8c858c93dd61fc625881616752e6b98f6"
-dependencies = [
- "cfg-if 1.0.0",
- "core-foundation-sys",
- "libc",
- "objc",
 ]
 
 [[package]]
@@ -7479,9 +7489,9 @@ dependencies = [
 
 [[package]]
 name = "tauri"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1ebb60bb8f246d5351ff9b7728fdfa7a6eba72baa722ab6021d553981caba1"
+checksum = "a27f85e61269f2bbefbe5e20e3ca4fab41390eb5b7c9717db8d9e725a66f9cf7"
 dependencies = [
  "anyhow",
  "attohttpc",
@@ -7533,9 +7543,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7b26eb3523e962b90012fedbfb744ca153d9be85e7981e00737e106d5323941"
+checksum = "9e478fc3fb927877a5017ce9f4b78457077e450356f7702f2a02800551322af5"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -7548,13 +7558,14 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9468c5189188c820ef605dfe4937c768cb2918e9460c8093dc4ee2cbd717b262"
+checksum = "9b11c52969592e6e420733987dff01f683270dbe63b8e5dc08e67f31421d6a78"
 dependencies = [
  "base64 0.13.0",
  "brotli",
  "ico",
+ "plist",
  "png 0.17.5",
  "proc-macro2",
  "quote",
@@ -7565,15 +7576,16 @@ dependencies = [
  "sha2 0.10.2",
  "tauri-utils",
  "thiserror",
+ "time 0.3.11",
  "uuid 1.1.2",
  "walkdir",
 ]
 
 [[package]]
 name = "tauri-macros"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e3ffddd7a274fc7baaa260888c971a0d95d2ef403aa16600c878b8b1c00ffe"
+checksum = "05891975005cd3c4d4b49cd23a2cfe79a3e7b4a2a35f1a91b5422836771180a7"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -7599,14 +7611,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7dc4db360bb40584187b6cb7834da736ce4ef2ab0914e2be98014444fa9920"
+checksum = "e0d5bcd2904326625080920568720e1ec9ee2bdc470da768510515206eb777a2"
 dependencies = [
  "gtk",
  "http",
  "http-range",
  "infer",
+ "raw-window-handle",
  "serde",
  "serde_json",
  "tauri-utils",
@@ -7618,14 +7631,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c876fb3a6e7c6fe2ac466b2a6ecd83658528844b4df0914558a9bc1501b31cf3"
+checksum = "b6690c56286f30ea4928b21e0fa015b3ba616b895df91f303b0d4c4a754ee769"
 dependencies = [
  "cocoa",
  "gtk",
  "percent-encoding 2.1.0",
  "rand 0.8.5",
+ "raw-window-handle",
  "tauri-runtime",
  "tauri-utils",
  "uuid 1.1.2",
@@ -7637,9 +7651,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727145cb55b8897fa9f2bcea4fad31dc39394703d037c9669b40f2d1c0c2d7f3"
+checksum = "8dfceaee3eb5369fd140ffe7f7c4cd7b44d2eb2f57513ef7e37e8d1ec587b983"
 dependencies = [
  "brotli",
  "ctor",
@@ -7659,6 +7673,7 @@ dependencies = [
  "thiserror",
  "url 2.2.2",
  "walkdir",
+ "windows 0.37.0",
 ]
 
 [[package]]
@@ -7810,6 +7825,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
 dependencies = [
+ "itoa 1.0.2",
  "libc",
  "num_threads",
 ]
@@ -9097,9 +9113,9 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.18.3"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b1ba327c7dd4292f46bf8e6ba8e6ec2db4443b2973c9d304a359d95e0aa856"
+checksum = "ce19dddbd3ce01dc8f14eb6d4c8f914123bf8379aaa838f6da4f981ff7104a3f"
 dependencies = [
  "block",
  "cocoa",

--- a/applications/launchpad/backend/Cargo.toml
+++ b/applications/launchpad/backend/Cargo.toml
@@ -11,7 +11,7 @@ build = "src/build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [build-dependencies]
-tauri-build = { version = "1.0.0", features = [] }
+tauri-build = { version = "1.0.1", features = [] }
 
 [dependencies]
 tari_common_types = { path = "../../../base_layer/common_types"}
@@ -30,7 +30,7 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 strum = "0.23.0"
 strum_macros = "0.23.0"
-tauri = { version = "1.0.0", features = ["api-all", "cli", "macos-private-api"] }
+tauri = { version = "1.0.1", features = ["api-all", "cli", "macos-private-api"] }
 tor-hash-passwd = "1.0.1"
 thiserror = "1.0.30"
 tokio = { version = "1.9", features= ["sync"] }

--- a/applications/launchpad/package.json
+++ b/applications/launchpad/package.json
@@ -4,6 +4,6 @@
     "dev-vue": "tauri dev -c tauri.vue.conf.json"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^1.0.0-rc.13"
+    "@tauri-apps/cli": "^1.0.1"
   }
 }

--- a/applications/launchpad/yarn.lock
+++ b/applications/launchpad/yarn.lock
@@ -2,62 +2,62 @@
 # yarn lockfile v1
 
 
-"@tauri-apps/cli-darwin-arm64@1.0.0-rc.13":
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.0.0-rc.13.tgz#da73a770835ffd63a149d8becf50d3781e1c97dd"
-  integrity sha512-/EqOz7ASHOU98H58Ibbkg12pLG/P5oyQz8OlueaMYryajkJdmi+bHTkJ05DfbS0owAaHkRJ6f+NmoW/AnyqUbg==
+"@tauri-apps/cli-darwin-arm64@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-darwin-arm64/-/cli-darwin-arm64-1.0.1.tgz#e7edecb70a052e46786274e37d544eebc8149221"
+  integrity sha512-VxRL1HFkVKvAZ1jHvRN0V8hbk1klRfCGbEz3u0QU5nzt4PnScgvOTc6S4wB54Lb9wweHdmXFqA4p9nfziyRgaQ==
 
-"@tauri-apps/cli-darwin-x64@1.0.0-rc.13":
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.0-rc.13.tgz#e120cc623fddca3eb9d7fea0c2de057c7440a821"
-  integrity sha512-bvZ0MBKFD1kc4gdVPXgwUA6tHNKj0EmlQK0Xolk6PYP9vZZeNTP1vejevW0bh2IqxC8DuqUArbG9USXwu+LFbQ==
+"@tauri-apps/cli-darwin-x64@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-darwin-x64/-/cli-darwin-x64-1.0.1.tgz#3dc1161d7b834dec7587680c0d0ff1d12a2abc21"
+  integrity sha512-Jml4FYeWJFEwcfDCOWcxMMXI7X8ahl7KLncarQ/u7Ql6JBFpSfV6Cb8eDNUEevlZxWDNksgVki9m1lL44fKblw==
 
-"@tauri-apps/cli-linux-arm-gnueabihf@1.0.0-rc.13":
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.0.0-rc.13.tgz#3052a59788ae57ad690d4bc09bf0756bc8808116"
-  integrity sha512-yODvfUkNvtYYdDTOJSDXMx9fpoEB66I2PTrYx1UKonKTEaLrQDcpw2exD/S9LPQzCYgyTuJ/kHRhG1uLdO/UUQ==
+"@tauri-apps/cli-linux-arm-gnueabihf@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-linux-arm-gnueabihf/-/cli-linux-arm-gnueabihf-1.0.1.tgz#be091e4a2c31d2716c1072345df20233c41adf18"
+  integrity sha512-RvHQeSmzUsM7G4MoMK9+DYYrypSA15Ev+7KbQCU5E7o3qmJ7jf2oYWVkeEWeYOthmikW1tNKel2roJQDkajEDg==
 
-"@tauri-apps/cli-linux-arm64-gnu@1.0.0-rc.13":
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.0-rc.13.tgz#9c4094473890c165a4fb22132229ed8212559f79"
-  integrity sha512-kVDJHERD8CmTeMcd2VTnD/nVCHdnNAK8a6ur3l0KTR1iF8A1AtN/sPahMQjK4f7Ar00UDjIzTw74liqakOeiZg==
+"@tauri-apps/cli-linux-arm64-gnu@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-linux-arm64-gnu/-/cli-linux-arm64-gnu-1.0.1.tgz#c7b6bff7920559b4e3437d6a27bd98e15395cd9d"
+  integrity sha512-Jv05qEkNfWQ4b0oM0wIWZBYj4c5likjFBkWdJ8ixeCcTVbQWR735buWEb9GcWpD5ju2pETH6r+AfmyHlbz+wvA==
 
-"@tauri-apps/cli-linux-arm64-musl@1.0.0-rc.13":
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.0-rc.13.tgz#16270a6d3b9289993b9b4d837f63dba4991d9be5"
-  integrity sha512-PFHz+0xKCGMqqn2TmbOSPvTRS61xJQV7srwTZjs5sHBvK536mdBnF/6V6BPEvTn5LzfRnxMu2A5X5GFkYnrZ7w==
+"@tauri-apps/cli-linux-arm64-musl@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.0.1.tgz#40ed7cbf32c47168baf0b7bc59ef881facc60166"
+  integrity sha512-EkQyRRPgZ7PcwqpxiZ7p8gYv9j/8m3s67b6ddiybGthPWNPC1ZeZocZ7HJfcwQr9nABDWnLAxTfnUm5N/waCwQ==
 
-"@tauri-apps/cli-linux-x64-gnu@1.0.0-rc.13":
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.0-rc.13.tgz#d2f5031f9597300a5814dc8b4d3c59e8dc25a871"
-  integrity sha512-EWhTOUNHaaMM7mxp/ue+Osnzn6/o9/7qVle3MSnNI9pGQzumc/dOtBs+sWS/NPXdVEiWKET2mFMK120KJlYcQQ==
+"@tauri-apps/cli-linux-x64-gnu@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-linux-x64-gnu/-/cli-linux-x64-gnu-1.0.1.tgz#6e806956fab6cec1ef53adca1818fb860ec8b023"
+  integrity sha512-VlwXXG2XoSv1MvIruCHQCh5gYcFVtCtkTQVRlMiGSUrv2UCAaHYpUxmgv1XEausqe0tpLrmWMUU4BqKrPXbsxg==
 
-"@tauri-apps/cli-linux-x64-musl@1.0.0-rc.13":
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.0-rc.13.tgz#9d8b02de7bd5af71c5d3d5be96ec88f3f29c8fbd"
-  integrity sha512-i8lsKw5iAGTAhqSQHeUCISLjhRXNrloHPoFCaSZtU0/GAPGbW/qST7u593h7cKWxRooeMwzo74ij4GhgmddClQ==
+"@tauri-apps/cli-linux-x64-musl@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-linux-x64-musl/-/cli-linux-x64-musl-1.0.1.tgz#c429c6d8bab2f7c31ff414c033940af13d653129"
+  integrity sha512-WlWIqLf44o9JmVg34uFIpHbklg4B9jdLMlscx7W9ueoOh059yX3TjdEwrD+L91qpgyvh8MLHDbDmCZ1BUm/v5w==
 
-"@tauri-apps/cli-win32-ia32-msvc@1.0.0-rc.13":
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-1.0.0-rc.13.tgz#1fcf6bed5a89af2cb30a2fe2e823ca486ded61b7"
-  integrity sha512-rJxSqWIQXeeT2oLzSiQyqZPgDKSGH5sK7MUr8cOCBitqy3T0COlOMX4O7hhqF3cJ/5s0aX+MuNZBzF/D0QUcxA==
+"@tauri-apps/cli-win32-ia32-msvc@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-win32-ia32-msvc/-/cli-win32-ia32-msvc-1.0.1.tgz#6101b1053afd3773f9ae8f31502799cb7b2d784b"
+  integrity sha512-jf8wIMNclPNIyqwTZBslTr9hpVmDb8tsEFqWLiV9lcCepovZZO7Jzkj3VVSNXV0QZkizIdh6YMvcFxZTazuGKA==
 
-"@tauri-apps/cli-win32-x64-msvc@1.0.0-rc.13":
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.0-rc.13.tgz#ed2feaf3b3a120c1460cae8941443563d14840bb"
-  integrity sha512-ifOTrJVQoBAQUYX+EVnE4XJ/FCMHs4FQ8qxGNszqkSxrU24mmT7La6tzj77352q80KnxRa05xjjLL6GGhmzXRg==
+"@tauri-apps/cli-win32-x64-msvc@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/cli-win32-x64-msvc/-/cli-win32-x64-msvc-1.0.1.tgz#534cd0873db4f4005bb9401fbccacb47a64f637f"
+  integrity sha512-6taaAkhxY9V9boCC2BUI/PtnAqz/jX5xnZFVWxY+CiE5HOt/tY6ZqSOWef3/wH8Q6fjg14xP4d7Xg3dA+rIiSw==
 
-"@tauri-apps/cli@^1.0.0-rc.13":
-  version "1.0.0-rc.13"
-  resolved "https://registry.yarnpkg.com/@tauri-apps/cli/-/cli-1.0.0-rc.13.tgz#e58127ebe24c6cc81c3258229219056199421500"
-  integrity sha512-q7i45Mi1SMv5XllNoX09QS4Q/fYVFwD6piVYmqMSrKY/T5RwedQhytiVH60TxC2xk6o0akVHa7BdYiyJvXNR8A==
+"@tauri-apps/cli@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tauri-apps/cli/-/cli-1.0.1.tgz#ec516be3d07c73d405532c127a4866a56f9004f1"
+  integrity sha512-PBRZ+PF7CZWAh6sWcZi6YNzecw6x9xykjhNVJ/IrGmePKlKJpMMuMUnjt1CZGD4YKdOKCy6hFnckoajMYKoAEQ==
   optionalDependencies:
-    "@tauri-apps/cli-darwin-arm64" "1.0.0-rc.13"
-    "@tauri-apps/cli-darwin-x64" "1.0.0-rc.13"
-    "@tauri-apps/cli-linux-arm-gnueabihf" "1.0.0-rc.13"
-    "@tauri-apps/cli-linux-arm64-gnu" "1.0.0-rc.13"
-    "@tauri-apps/cli-linux-arm64-musl" "1.0.0-rc.13"
-    "@tauri-apps/cli-linux-x64-gnu" "1.0.0-rc.13"
-    "@tauri-apps/cli-linux-x64-musl" "1.0.0-rc.13"
-    "@tauri-apps/cli-win32-ia32-msvc" "1.0.0-rc.13"
-    "@tauri-apps/cli-win32-x64-msvc" "1.0.0-rc.13"
+    "@tauri-apps/cli-darwin-arm64" "1.0.1"
+    "@tauri-apps/cli-darwin-x64" "1.0.1"
+    "@tauri-apps/cli-linux-arm-gnueabihf" "1.0.1"
+    "@tauri-apps/cli-linux-arm64-gnu" "1.0.1"
+    "@tauri-apps/cli-linux-arm64-musl" "1.0.1"
+    "@tauri-apps/cli-linux-x64-gnu" "1.0.1"
+    "@tauri-apps/cli-linux-x64-musl" "1.0.1"
+    "@tauri-apps/cli-win32-ia32-msvc" "1.0.1"
+    "@tauri-apps/cli-win32-x64-msvc" "1.0.1"


### PR DESCRIPTION
Description
---

Upgrades backend to 1.0.1 and tauri-cli to 1.0.1

Motivation and Context
---

How Has This Been Tested?
---

```
$ cd applications/backend
$ cargo clean
$ cargo build

$ cd applications/launchpad
$ rm yarn.lock
$ rm -rf node_modules
$ yarn install

$ yarn tauri dev
```