### PR TITLE
feat: display emoji Id and wait for wallet backend

### DIFF
--- a/applications/launchpad/backend/src/grpc/mod.rs
+++ b/applications/launchpad/backend/src/grpc/mod.rs
@@ -35,6 +35,7 @@ pub struct WalletIdentity {
     emoji_id: String,
 }
 #[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct WalletBalance {
     available_balance: u64,
     pending_incoming_balance: u64,

--- a/applications/launchpad/gui-react/__tests__/mocks/states/walletStateTemplates.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/states/walletStateTemplates.ts
@@ -1,22 +1,26 @@
 import { WalletState } from '../../../src/store/wallet/types'
 
 export const initialWallet: WalletState = {
-  running: false,
-  pending: false,
-  address: '',
+  address: {
+    uri: '',
+    emoji: '',
+  },
   unlocked: false,
   tari: {
+    pending: false,
     balance: 0,
     available: 0,
   },
 }
 
 export const unlockedWallet: WalletState = {
-  running: false,
-  pending: false,
-  address: 'someWalletAddress',
+  address: {
+    uri: 'someWalletAddress',
+    emoji: '',
+  },
   unlocked: true,
   tari: {
+    pending: false,
     balance: 0,
     available: 0,
   },
@@ -24,11 +28,12 @@ export const unlockedWallet: WalletState = {
 
 export const runningWallet = (
   address = 'the-wallet-address',
-  tari = { balance: 0, available: 0 },
+  tari = { balance: 0, available: 0, pending: false },
 ): WalletState => ({
-  running: true,
-  pending: false,
-  address,
+  address: {
+    uri: address,
+    emoji: '',
+  },
   unlocked: true,
   tari,
 })

--- a/applications/launchpad/gui-react/src/components/CopyBox/index.tsx
+++ b/applications/launchpad/gui-react/src/components/CopyBox/index.tsx
@@ -22,17 +22,20 @@ const CopyBox = ({
   label,
   value,
   style,
+  valueTransform,
 }: {
   label?: string
   value: string
   style?: CSSProperties
+  valueTransform?: (s: string) => string
 }) => {
   const [copied, setCopied] = useState(false)
   const styles = useSpring({ opacity: copied ? 1 : 0 })
   const timeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
   const copy = async () => {
-    await clipboard.writeText(value)
+    const transformed = valueTransform ? valueTransform(value) : value
+    await clipboard.writeText(transformed)
 
     setCopied(true)
     if (timeout.current) {

--- a/applications/launchpad/gui-react/src/components/CopyBox/index.tsx
+++ b/applications/launchpad/gui-react/src/components/CopyBox/index.tsx
@@ -61,6 +61,7 @@ const CopyBox = ({
           style={{
             overflowX: 'hidden',
             textOverflow: 'ellipsis',
+            wordBreak: 'keep-all',
           }}
           title={value}
         >

--- a/applications/launchpad/gui-react/src/components/CopyBox/index.tsx
+++ b/applications/launchpad/gui-react/src/components/CopyBox/index.tsx
@@ -8,7 +8,7 @@ import Tag from '../Tag'
 import CopyIcon from '../../styles/Icons/Copy'
 import t from '../../locales'
 
-import { StyledBox, FeedbackContainer } from './styles'
+import { ValueContainer, StyledBox, FeedbackContainer } from './styles'
 
 /**
  * @name CopyBox
@@ -60,16 +60,7 @@ const CopyBox = ({
     <>
       {label && <Text>{label}</Text>}
       <StyledBox style={style}>
-        <div
-          style={{
-            overflowX: 'hidden',
-            textOverflow: 'ellipsis',
-            wordBreak: 'keep-all',
-          }}
-          title={value}
-        >
-          {value}
-        </div>
+        <ValueContainer title={value}>{value}</ValueContainer>
         <Button
           variant='text'
           style={{

--- a/applications/launchpad/gui-react/src/components/CopyBox/styles.ts
+++ b/applications/launchpad/gui-react/src/components/CopyBox/styles.ts
@@ -20,3 +20,11 @@ export const FeedbackContainer = styled.div`
   bottom: 120%;
   transform: translateX(-50%);
 `
+
+export const ValueContainer = styled.div`
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  word-break: keep-all;
+  -webkit-user-select: none;
+  cursor: default;
+`

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/WalletSettings/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/WalletSettings/index.tsx
@@ -2,7 +2,7 @@ import { useAppSelector, useAppDispatch } from '../../../store/hooks'
 import {
   selectIsPending,
   selectIsRunning,
-  selectState,
+  selectWalletAddress,
 } from '../../../store/wallet/selectors'
 import { actions as walletActions } from '../../../store/wallet'
 import { WalletPasswordPrompt } from '../../../useWithWalletPassword'
@@ -11,7 +11,7 @@ import WalletSettings from './WalletSettings'
 
 const WalletSettingsContainer = () => {
   const dispatch = useAppDispatch()
-  const { address } = useAppSelector(selectState)
+  const address = useAppSelector(selectWalletAddress)
   const running = useAppSelector(selectIsRunning)
   const pending = useAppSelector(selectIsPending)
 

--- a/applications/launchpad/gui-react/src/containers/WalletContainer/TariWallet/TariId.tsx
+++ b/applications/launchpad/gui-react/src/containers/WalletContainer/TariWallet/TariId.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { useTheme } from 'styled-components'
 
 import t from '../../../locales'
@@ -14,10 +14,20 @@ const TariId = ({
   emojiTariId,
 }: {
   tariId: string
-  emojiTariId: string[]
+  emojiTariId: string
 }) => {
   const [showEmoji, setShowEmoji] = useState(false)
   const theme = useTheme()
+
+  const displayedEmojiTariId = useMemo(() => {
+    const emojis = Array.from(emojiTariId)
+    const emojiChunks = []
+    for (let i = 0; i < emojis.length; i += 3) {
+      emojiChunks.push(emojis.slice(i, i + 3).join(''))
+    }
+
+    return emojiChunks.join(' | ')
+  }, [emojiTariId])
 
   return (
     <>
@@ -34,7 +44,7 @@ const TariId = ({
       </Text>
       <TariIdContainer>
         <CopyBox
-          value={showEmoji ? emojiTariId.join(' | ') : tariId}
+          value={showEmoji ? displayedEmojiTariId : tariId}
           style={{
             maxWidth: 'calc(100% - 2.4em)',
             borderColor: theme.borderColor,

--- a/applications/launchpad/gui-react/src/containers/WalletContainer/TariWallet/TariId.tsx
+++ b/applications/launchpad/gui-react/src/containers/WalletContainer/TariWallet/TariId.tsx
@@ -9,6 +9,10 @@ import CopyBox from '../../../components/CopyBox'
 import Smiley from './Smiley'
 import { SemiTransparent, TariIdContainer } from './styles'
 
+const SEPARATOR = ' | '
+
+const removeSeparators = (v: string) => v.replaceAll(SEPARATOR, '')
+
 const TariId = ({
   tariId,
   emojiTariId,
@@ -26,7 +30,7 @@ const TariId = ({
       emojiChunks.push(emojis.slice(i, i + 3).join(''))
     }
 
-    return emojiChunks.join(' | ')
+    return emojiChunks.join(SEPARATOR)
   }, [emojiTariId])
 
   return (
@@ -44,6 +48,7 @@ const TariId = ({
       </Text>
       <TariIdContainer>
         <CopyBox
+          valueTransform={showEmoji ? removeSeparators : undefined}
           value={showEmoji ? displayedEmojiTariId : tariId}
           style={{
             maxWidth: 'calc(100% - 2.4em)',

--- a/applications/launchpad/gui-react/src/containers/WalletContainer/TariWallet/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/WalletContainer/TariWallet/index.tsx
@@ -14,7 +14,7 @@ const TariWallet = ({
   running,
 }: {
   address: string
-  emojiId: string[]
+  emojiId: string
   running: boolean
 }) => {
   const theme = useTheme()

--- a/applications/launchpad/gui-react/src/containers/WalletContainer/index.test.tsx
+++ b/applications/launchpad/gui-react/src/containers/WalletContainer/index.test.tsx
@@ -42,7 +42,7 @@ describe('WalletContainer', () => {
           preloadedState: {
             wallet: {
               ...walletInitialState,
-              address: 'configuredWalletAddress',
+              address: { uri: 'configuredWalletAddress', emoji: '' },
               unlocked: false,
             },
           },
@@ -66,7 +66,7 @@ describe('WalletContainer', () => {
           preloadedState: {
             wallet: {
               ...walletInitialState,
-              address: 'configuredWalletAddress',
+              address: { uri: 'configuredWalletAddress', emoji: '' },
               unlocked: true,
             },
           },
@@ -90,7 +90,7 @@ describe('WalletContainer', () => {
           preloadedState: {
             wallet: {
               ...walletInitialState,
-              address: 'configuredWalletAddress',
+              address: { uri: 'configuredWalletAddress', emoji: '' },
               unlocked: true,
             },
           },

--- a/applications/launchpad/gui-react/src/store/mining/thunks.test.ts
+++ b/applications/launchpad/gui-react/src/store/mining/thunks.test.ts
@@ -39,7 +39,10 @@ describe('starting node', () => {
     const getState = () =>
       ({
         wallet: {
-          address: '',
+          address: {
+            uri: '',
+            emoji: '',
+          },
           unlocked: false,
         },
         mining: {
@@ -74,7 +77,10 @@ describe('starting node', () => {
     const getState = () =>
       ({
         wallet: {
-          address: '',
+          address: {
+            uri: '',
+            emoji: '',
+          },
           unlocked: false,
         },
         mining: {
@@ -110,7 +116,10 @@ describe('starting node', () => {
     const getState = () =>
       ({
         wallet: {
-          address: 'some wallet adress',
+          address: {
+            uri: 'some wallet adress',
+            emoji: '',
+          },
           unlocked: true,
         },
         mining: {
@@ -150,7 +159,10 @@ describe('start stop mining', () =>
         const getState = () =>
           ({
             wallet: {
-              address: 'walletAddress',
+              address: {
+                uri: 'walletAddress',
+                emoji: '',
+              },
               unlocked: true,
             },
             mining: {
@@ -189,7 +201,10 @@ describe('start stop mining', () =>
         const getState = () =>
           ({
             wallet: {
-              address: 'some wallet adress',
+              address: {
+                uri: 'some wallet adress',
+                emoji: '',
+              },
               unlocked: true,
             },
             mining: {
@@ -234,7 +249,10 @@ describe('start stop mining', () =>
         const getState = () =>
           ({
             wallet: {
-              address: 'some wallet adress',
+              address: {
+                uri: 'some wallet adress',
+                emoji: '',
+              },
               unlocked: true,
             },
             mining: {
@@ -281,7 +299,10 @@ describe('start stop mining', () =>
           const getState = () =>
             ({
               wallet: {
-                address: 'some wallet adress',
+                address: {
+                  uri: 'some wallet adress',
+                  emoji: '',
+                },
                 unlocked: true,
               },
               containers: allStopped,
@@ -330,7 +351,10 @@ describe('start stop mining', () =>
           const getState = () =>
             ({
               wallet: {
-                address: 'some wallet adress',
+                address: {
+                  uri: 'some wallet adress',
+                  emoji: '',
+                },
                 unlocked: true,
               },
               containers: allStopped,
@@ -390,7 +414,10 @@ describe('start stop mining', () =>
         const getState = () =>
           ({
             wallet: {
-              address: 'some wallet adress',
+              address: {
+                uri: 'some wallet adress',
+                emoji: '',
+              },
               unlocked: true,
             },
             containers: allStopped,
@@ -434,7 +461,10 @@ describe('start stop mining', () =>
         const getState = () =>
           ({
             wallet: {
-              address: 'some wallet adress',
+              address: {
+                uri: 'some wallet adress',
+                emoji: '',
+              },
               unlocked: true,
             },
             containers: allStopped,

--- a/applications/launchpad/gui-react/src/store/wallet/index.ts
+++ b/applications/launchpad/gui-react/src/store/wallet/index.ts
@@ -5,7 +5,10 @@ import { unlockWallet, start, stop, updateWalletBalance } from './thunks'
 
 export const initialState: WalletState = {
   unlocked: false,
-  address: '',
+  address: {
+    uri: '',
+    emoji: '',
+  },
   tari: {
     balance: 0,
     available: 0,

--- a/applications/launchpad/gui-react/src/store/wallet/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/wallet/selectors.ts
@@ -7,26 +7,19 @@ import {
 
 import { WalletSetupRequired } from './types'
 
-export const selectState = (state: RootState) => state.wallet
 export const selectIsUnlocked = (state: RootState) => state.wallet.unlocked
-export const selectWalletAddress = (state: RootState) => state.wallet.address
-export const selectWalletEmojiAddress = () => [
-  '🐎🍴🌷',
-  '🌟💻🐖',
-  '🐩🐾🌟',
-  '🐬🎧🐌',
-  '🏦🐳🐎',
-  '🐝🐢🔋',
-  '👕🎸👿',
-  '🍒🐓🎉',
-  '💔🌹🏆',
-  '🐬💡🎳',
-  '🚦🍹🎒',
-]
+
+export const selectWalletAddress = (state: RootState) =>
+  state.wallet.address.uri
+export const selectWalletEmojiAddress = (state: RootState) =>
+  state.wallet.address.emoji
+
 export const selectTariBalance = (state: RootState) => state.wallet.tari
 
 export const selectWalletSetupRequired = (state: RootState) =>
-  !state.wallet.address ? WalletSetupRequired.MissingWalletAddress : undefined
+  !state.wallet.address.uri
+    ? WalletSetupRequired.MissingWalletAddress
+    : undefined
 
 export const selectIsPending = selectRecipePending(Container.Wallet)
 

--- a/applications/launchpad/gui-react/src/store/wallet/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/wallet/thunks.ts
@@ -8,11 +8,11 @@ import * as walletService from './walletService'
 
 // TODO backend communication
 const waitForWalletToBeResponsive = () =>
-  new Promise(resolve => setTimeout(resolve, 200))
+  new Promise(resolve => setTimeout(resolve, 4000))
 
 export const unlockWallet = createAsyncThunk<
   {
-    address: string
+    address: { uri: string; emoji: string }
     tari: { balance: number; available: number }
   },
   void,
@@ -38,7 +38,10 @@ export const unlockWallet = createAsyncThunk<
     ])
 
     return {
-      address: walletIdentity.publicAddress,
+      address: {
+        uri: walletIdentity.publicAddress,
+        emoji: walletIdentity.emojiId,
+      },
       tari: {
         balance:
           tari.availableBalance -

--- a/applications/launchpad/gui-react/src/store/wallet/types.ts
+++ b/applications/launchpad/gui-react/src/store/wallet/types.ts
@@ -4,7 +4,10 @@ export enum WalletSetupRequired {
 
 export type WalletState = {
   unlocked: boolean
-  address: string
+  address: {
+    uri: string
+    emoji: string
+  }
   tari: {
     balance: number
     available: number

--- a/applications/launchpad/gui-react/src/store/wallet/walletService.ts
+++ b/applications/launchpad/gui-react/src/store/wallet/walletService.ts
@@ -4,9 +4,10 @@ import { toT } from '../../utils/Format'
 
 interface WalletIdentityDto {
   publicAddress: string
+  emojiId: string
 }
 export const getIdentity: () => Promise<WalletIdentityDto> = () =>
-  invoke('wallet_identity')
+  invoke<WalletIdentityDto>('wallet_identity')
 
 interface WalletBalanceDto {
   availableBalance: number

--- a/applications/launchpad/gui-react/src/store/wallet/walletService.ts
+++ b/applications/launchpad/gui-react/src/store/wallet/walletService.ts
@@ -2,14 +2,14 @@ import { invoke } from '@tauri-apps/api/tauri'
 
 import { toT } from '../../utils/Format'
 
-interface WalletIdentityDto {
+export interface WalletIdentityDto {
   publicAddress: string
   emojiId: string
 }
 export const getIdentity: () => Promise<WalletIdentityDto> = () =>
   invoke<WalletIdentityDto>('wallet_identity')
 
-interface WalletBalanceDto {
+export interface WalletBalanceDto {
   availableBalance: number
   pendingIncomingBalance: number
   pendingOutgoingBalance: number


### PR DESCRIPTION
Description
---

- [x] display emojiId downloaded from backend when wallet is unlocked
- [x] added transformation on a copy - removing `|` separators from copied emoji wallet
- [x] poll for wallet data

Motivation and Context
---

#257 (part)

How Has This Been Tested?
---
![image](https://user-images.githubusercontent.com/9142942/176701767-7d07453c-2ef7-44cc-b9a5-0993f70de8b0.png)
![image](https://user-images.githubusercontent.com/9142942/177213448-469f3c18-62c4-48db-a07b-56ddd9ddf7a2.png)
