### PR TITLE
chore(deps): improve GHA docker image builds TAG version

### DIFF
--- a/.github/workflows/tags-launchpad-docker-images.yml
+++ b/.github/workflows/tags-launchpad-docker-images.yml
@@ -101,8 +101,8 @@ jobs:
             DOCKERFILE=${IMAGE}.Dockerfile
             DOCKERCONTEXT=./applications/launchpad/docker_rig/
 
-            # Pull the docker image TAG from dockerfile
-            SUBTAG=$(awk -F '=' '/ARG .*_VERSION=/ \
+            # Pull the docker image version TAG from service dockerfile
+            SUBTAG=$(awk -v search="^ARG ${IMAGE^^}?_VERSION=" -F '=' '$0 ~ search \
               { gsub(/["]/, "", $2); printf("%s",$2) }' \
               "${GITHUB_WORKSPACE}/${DOCKERCONTEXT}${DOCKERFILE}")
 


### PR DESCRIPTION
Description
Fixed GHA service TAG version from service dockerfile.

Used to pick up only the service ARG version.

Motivation and Context
Remove the need for a version/env file for tracking the released versions for sub-services and still support version overrides

How Has This Been Tested?
Build in my branch from GHA into Quay.io
