### PR TITLE
feat: set coinbase flag to inbound transactions

### DIFF
--- a/applications/tari_console_wallet/src/grpc/mod.rs
+++ b/applications/tari_console_wallet/src/grpc/mod.rs
@@ -51,8 +51,15 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             status: inbound.status.to_string(),
             direction: "inbound".to_string(),
             amount: inbound.amount.as_u64(),
-            message: inbound.message,
-            is_coinbase: false,
+            message: inbound.message.clone(),
+            ///The coinbase are technically Inbound.
+            /// To determine whether a transaction is coinbase 
+            /// we will check whether the message contains `Coinbase`.
+            is_coinbase: if inbound.message.to_lowercase().contains("coinbase") {
+                true
+            } else {
+                false
+            },
         },
     }
 }

--- a/applications/tari_console_wallet/src/grpc/mod.rs
+++ b/applications/tari_console_wallet/src/grpc/mod.rs
@@ -52,8 +52,8 @@ pub fn convert_to_transaction_event(event: String, source: TransactionWrapper) -
             direction: "inbound".to_string(),
             amount: inbound.amount.as_u64(),
             message: inbound.message.clone(),
-            ///The coinbase are technically Inbound.
-            /// To determine whether a transaction is coinbase 
+            /// The coinbase are technically Inbound.
+            /// To determine whether a transaction is coinbase
             /// we will check whether the message contains `Coinbase`.
             is_coinbase: if inbound.message.to_lowercase().contains("coinbase") {
                 true


### PR DESCRIPTION
Description

feat #286 
The coinbase transactions are technically inbound messages.
We set the flag `is_coinbase`: true only for `COMPLETED` transactions.
To set it correct for `INBOUND` messages as well we should check whether message contains `COINBASE`.

Motivation and Context
User should be able to see the earned tips.


How Has This Been Tested?
Manually tested.