### PR TITLE
feat: base node qr url

### DIFF
--- a/applications/launchpad/backend/src/main.rs
+++ b/applications/launchpad/backend/src/main.rs
@@ -41,7 +41,7 @@ use tauri::{
 use tauri_plugin_sql::{Migration, MigrationKind, TauriSql};
 
 use crate::{
-    api::{base_node_sync_progress, image_info, network_list, wallet_balance, wallet_events, wallet_identity},
+    api::{base_node_sync_progress, image_info, network_list, node_identity, wallet_balance, wallet_events, wallet_identity},
     commands::{
         create_default_workspace,
         create_new_workspace,
@@ -155,6 +155,7 @@ fn main() {
             create_default_workspace,
             events,
             launch_docker,
+            node_identity,
             start_service,
             stop_service,
             shutdown,

--- a/applications/launchpad/backend/src/main.rs
+++ b/applications/launchpad/backend/src/main.rs
@@ -41,7 +41,15 @@ use tauri::{
 use tauri_plugin_sql::{Migration, MigrationKind, TauriSql};
 
 use crate::{
-    api::{base_node_sync_progress, image_info, network_list, node_identity, wallet_balance, wallet_events, wallet_identity},
+    api::{
+        base_node_sync_progress,
+        image_info,
+        network_list,
+        node_identity,
+        wallet_balance,
+        wallet_events,
+        wallet_identity,
+    },
     commands::{
         create_default_workspace,
         create_new_workspace,

--- a/applications/launchpad/gui-react/__tests__/mocks/states/baseNodeStateTemplates.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/states/baseNodeStateTemplates.ts
@@ -1,0 +1,15 @@
+import { BaseNodeState } from '../../../src/store/baseNode/types'
+
+export const baseNodeAllState: BaseNodeState = {
+  network: 'dibbler',
+  rootFolder: 'path-to-the-root-folder',
+  identity: {
+    publicKey:
+      'bc3a3063677589fb0fc1957a77f1fdbbd023aa5fa19f1297e66361cc03a19567',
+    nodeId: 'e5e915c44fcffaa37fd764f587',
+    publicAddress:
+      '/onion3/cdqxb4njbbvrdsahjtiqa7cb5qhjshlqw7u5huxwu2oja4h4ewxoeuid:18141',
+    emojiId:
+      '💨🍹🍬🏆🏥🐗🐴🚫🌸💳👑🐜🐙🚒🚽💦🔋🍓👿🎾👟👛🌽👓😎🏆🏀📡🌊👟👑🏥🍯',
+  },
+}

--- a/applications/launchpad/gui-react/__tests__/mocks/states/index.ts
+++ b/applications/launchpad/gui-react/__tests__/mocks/states/index.ts
@@ -1,3 +1,4 @@
+export * from './baseNodeStateTemplates'
 export * from './containersStateTemplates'
 export * from './miningStateTemplates'
 export * from './walletStateTemplates'

--- a/applications/launchpad/gui-react/src/components/TransactionsList/index.tsx
+++ b/applications/launchpad/gui-react/src/components/TransactionsList/index.tsx
@@ -17,19 +17,7 @@ import { TransactionsListProps } from './types'
 import { TransactionDBRecord } from '../../persistence/transactionsRepository'
 import SvgArrowLeft from '../../styles/Icons/ArrowLeft'
 import Tag from '../Tag'
-import { toT } from '../../utils/Format'
-
-const convertU8ToString = (data: string) => {
-  try {
-    if (!data || data === '[]') {
-      return ''
-    }
-    const parsed = data.replace('[', '').replace(']', '').split(',')
-    return parsed.map(c => String.fromCharCode(Number(c))).join('')
-  } catch (_) {
-    return ''
-  }
-}
+import { convertU8ToString, toT } from '../../utils/Format'
 
 const trimAddress = (address: string, start = 4, end = 4) => {
   return (

--- a/applications/launchpad/gui-react/src/containers/BaseNodeContainer/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeContainer/index.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 
 import { useAppSelector, useAppDispatch } from '../../store/hooks'
 import {
-  selectState,
   selectPending,
   selectRunning,
   selectNetwork,

--- a/applications/launchpad/gui-react/src/containers/BaseNodeContainer/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeContainer/index.tsx
@@ -5,6 +5,7 @@ import {
   selectState,
   selectPending,
   selectRunning,
+  selectNetwork,
 } from '../../store/baseNode/selectors'
 import { actions } from '../../store/baseNode'
 import Alert from '../../components/Alert'
@@ -13,11 +14,12 @@ import t from '../../locales'
 
 import BaseNode from './BaseNode'
 import BaseNodeHelp from './BaseNodeHelp'
+import { Network } from './types'
 
 const BaseNodeContainer = () => {
   const [error, setError] = useState('')
 
-  const { network } = useAppSelector(selectState)
+  const network = useAppSelector(selectNetwork) as Network
   const pending = useAppSelector(selectPending)
   const running = useAppSelector(selectRunning)
   const dispatch = useAppDispatch()

--- a/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/BaseNodeQRModal.test.tsx
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/BaseNodeQRModal.test.tsx
@@ -1,16 +1,31 @@
 import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
 import { ThemeProvider } from 'styled-components'
 
+import { baseNodeAllState } from '../../../__tests__/mocks/states'
+
 import themes from '../../styles/themes'
+
+import { rootReducer } from '../../store'
 
 import BaseNodeQRModal from '.'
 
 describe('BaseNodeQRModal', () => {
   it('should render modal with the QR Code without crashing', () => {
     const onCloseFn = jest.fn()
+    const store = configureStore({
+      reducer: rootReducer,
+      preloadedState: {
+        baseNode: baseNodeAllState,
+      },
+    })
+
     render(
       <ThemeProvider theme={themes.light}>
-        <BaseNodeQRModal open onClose={onCloseFn} />
+        <Provider store={store}>
+          <BaseNodeQRModal open onClose={onCloseFn} />
+        </Provider>
       </ThemeProvider>,
     )
 

--- a/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/index.tsx
@@ -7,9 +7,13 @@ import Modal from '../../components/Modal'
 import Text from '../../components/Text'
 
 import t from '../../locales'
-import { selectNetwork } from '../../store/baseNode/selectors'
-import { useAppSelector } from '../../store/hooks'
-import { selectWalletAddress } from '../../store/wallet/selectors'
+import {
+  selectBaseNodeIdentity,
+  selectNetwork,
+  selectRunning,
+} from '../../store/baseNode/selectors'
+import { useAppDispatch, useAppSelector } from '../../store/hooks'
+import { actions as baseNodeActions } from '../../store/baseNode'
 import {
   ModalContainer,
   Content,
@@ -28,22 +32,27 @@ import { BaseNodeQRModalProps } from './types'
  */
 const BaseNodeQRModal = ({ open, onClose }: BaseNodeQRModalProps) => {
   const theme = useTheme()
-  const address = useAppSelector(selectWalletAddress)
   const network = useAppSelector(selectNetwork)
+  const baseNodeIdentity = useAppSelector(selectBaseNodeIdentity)
+  const isBaseNodeRunning = useAppSelector(selectRunning)
 
-  /**
-   * @TODO Get following publicKey and baseNodeId from backend.
-   */
-  const publicKey = 'TODO_PUBLIC_KEY'
-  const baseNodeId = 'TODO_BASE_NODE_ID'
+  const dispatch = useAppDispatch()
 
   const [qrUrl, setQrUrl] = useState('')
 
   useEffect(() => {
-    setQrUrl(
-      `tari://${network}/base_nodes/add?name=${baseNodeId}&peer=${publicKey}::${address}`,
-    )
-  }, [address, network])
+    if (baseNodeIdentity) {
+      setQrUrl(
+        `tari://${network}/base_nodes/add?name=${baseNodeIdentity.nodeId}&peer=${baseNodeIdentity.publicKey}::${baseNodeIdentity.publicAddress}`,
+      )
+    }
+  }, [baseNodeIdentity, network])
+
+  useEffect(() => {
+    if (isBaseNodeRunning && open) {
+      dispatch(baseNodeActions.getBaseNodeIdentity())
+    }
+  }, [isBaseNodeRunning, open])
 
   return (
     <Modal open={open} onClose={onClose} size='small'>

--- a/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/BaseNodeQRModal/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import QRCode from 'react-qr-code'
 import { useTheme } from 'styled-components'
 import Button from '../../components/Button'
@@ -6,6 +7,9 @@ import Modal from '../../components/Modal'
 import Text from '../../components/Text'
 
 import t from '../../locales'
+import { selectNetwork } from '../../store/baseNode/selectors'
+import { useAppSelector } from '../../store/hooks'
+import { selectWalletAddress } from '../../store/wallet/selectors'
 import {
   ModalContainer,
   Content,
@@ -18,18 +22,29 @@ import {
 import { BaseNodeQRModalProps } from './types'
 
 /**
- * @TODO Replace with real data
- */
-const QRContent =
-  'tari://dibbler/base_nodes/add?name=00000000000000000000000000&peer=::/onion3/0000000000000000000000000000000000000000000000000000000000000000:00000'
-
-/**
  * The modal rendering the Base Node address as QR code.
  * @param {boolean} open - show modal
  * @param {() => void} onClose - on modal close
  */
 const BaseNodeQRModal = ({ open, onClose }: BaseNodeQRModalProps) => {
   const theme = useTheme()
+  const address = useAppSelector(selectWalletAddress)
+  const network = useAppSelector(selectNetwork)
+
+  /**
+   * @TODO Get following publicKey and baseNodeId from backend.
+   */
+  const publicKey = 'TODO_PUBLIC_KEY'
+  const baseNodeId = 'TODO_BASE_NODE_ID'
+
+  const [qrUrl, setQrUrl] = useState('')
+
+  useEffect(() => {
+    setQrUrl(
+      `tari://${network}/base_nodes/add?name=${baseNodeId}&peer=${publicKey}::${address}`,
+    )
+  }, [address, network])
+
   return (
     <Modal open={open} onClose={onClose} size='small'>
       <ModalContainer>
@@ -65,7 +80,7 @@ const BaseNodeQRModal = ({ open, onClose }: BaseNodeQRModalProps) => {
 
           <QRContainer>
             <QRCode
-              value={QRContent}
+              value={qrUrl}
               level='H'
               size={220}
               data-testid='base-node-qr-code'

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/BaseNodeSettings.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/BaseNodeSettings/BaseNodeSettings.tsx
@@ -47,6 +47,7 @@ const BaseNodeSettings = ({
       })
     }
   }, [])
+
   return (
     <>
       <Text type='subheader' as='h2' color={theme.primary}>

--- a/applications/launchpad/gui-react/src/containers/SettingsContainer/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/SettingsContainer/index.tsx
@@ -11,7 +11,7 @@ import {
   selectActiveSettings,
   selectServiceSettings,
 } from '../../store/settings/selectors'
-import { selectState as selectBaseNodeState } from '../../store/baseNode/selectors'
+import { selectNetwork, selectRootFolder } from '../../store/baseNode/selectors'
 import { saveSettings } from '../../store/settings/thunks'
 import { ThemeType } from '../../styles/themes/types'
 
@@ -25,7 +25,8 @@ const SettingsContainer = () => {
 
   const miningMerged = useAppSelector(selectMergedMiningState)
   const serviceSettings = useAppSelector(selectServiceSettings)
-  const baseNodeSettings = useAppSelector(selectBaseNodeState)
+  const baseNodeNetwork = useAppSelector(selectNetwork)
+  const baseNodeRootFolder = useAppSelector(selectRootFolder)
   const currentTheme = useAppSelector(selectTheme)
 
   const [openMiningAuthForm, setOpenMiningAuthForm] = useState(false)
@@ -47,8 +48,8 @@ const SettingsContainer = () => {
         registry: serviceSettings.dockerRegistry,
       },
       baseNode: {
-        rootFolder: baseNodeSettings.rootFolder,
-        network: baseNodeSettings.network,
+        rootFolder: baseNodeRootFolder,
+        network: baseNodeNetwork,
       },
     }),
     [miningMerged, serviceSettings],

--- a/applications/launchpad/gui-react/src/store/baseNode/baseNodeService.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/baseNodeService.ts
@@ -1,0 +1,5 @@
+import { invoke } from '@tauri-apps/api/tauri'
+import { BaseNodeIdentityDto } from './types'
+
+export const getIdentity: () => Promise<BaseNodeIdentityDto> = () =>
+  invoke<BaseNodeIdentityDto>('node_identity')

--- a/applications/launchpad/gui-react/src/store/baseNode/index.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/index.ts
@@ -1,11 +1,13 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-import { startNode, stopNode } from './thunks'
+import { getBaseNodeIdentity, startNode, stopNode } from './thunks'
 import { Network } from '../../containers/BaseNodeContainer/types'
+import { BaseNodeState } from './types'
 
-const initialState = {
+const initialState: BaseNodeState = {
   network: 'dibbler',
   rootFolder: '',
+  identity: undefined,
 }
 
 const baseNodeSlice = createSlice({
@@ -19,10 +21,16 @@ const baseNodeSlice = createSlice({
       state.rootFolder = action.payload
     },
   },
+  extraReducers: builder => {
+    builder.addCase(getBaseNodeIdentity.fulfilled, (state, action) => {
+      state.identity = action.payload
+    })
+  },
 })
 
 const { setTariNetwork, setRootFolder } = baseNodeSlice.actions
 export const actions = {
+  getBaseNodeIdentity,
   startNode,
   stopNode,
   setTariNetwork,

--- a/applications/launchpad/gui-react/src/store/baseNode/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/selectors.ts
@@ -14,7 +14,11 @@ export const selectState = (state: RootState): BaseNodeState => ({
 })
 
 export const selectNetwork = (state: RootState) => state.baseNode.network
+export const selectRootFolder = (state: RootState) => state.baseNode.rootFolder
 
 export const selectRunning = selectRecipeRunning(Container.BaseNode)
 
 export const selectPending = selectRecipePending(Container.BaseNode)
+
+export const selectBaseNodeIdentity = (state: RootState) =>
+  state.baseNode.identity

--- a/applications/launchpad/gui-react/src/store/baseNode/thunks.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/thunks.ts
@@ -1,8 +1,11 @@
 import { createAsyncThunk } from '@reduxjs/toolkit'
 
 import { RootState } from '..'
+import { bytesToHex } from '../../utils/Format'
 import { actions as containersActions } from '../containers'
 import { Container } from '../containers/types'
+import { getIdentity } from './baseNodeService'
+import { BaseNodeIdentity } from './types'
 
 export const startNode = createAsyncThunk<void, void, { state: RootState }>(
   'baseNode/startNode',
@@ -21,3 +24,21 @@ export const stopNode = createAsyncThunk<void, void, { state: RootState }>(
       .dispatch(containersActions.stopRecipe(Container.BaseNode))
       .unwrap(),
 )
+
+export const getBaseNodeIdentity = createAsyncThunk<
+  BaseNodeIdentity,
+  void,
+  { state: RootState }
+>('baseNode/getBaseNodeIdentity', async (_, thunkApi) => {
+  try {
+    const result = await getIdentity()
+    return {
+      publicAddress: result.publicAddress,
+      publicKey: bytesToHex(result.publicKey),
+      nodeId: bytesToHex(result.nodeId),
+      emojiId: result.emojiId,
+    }
+  } catch (err) {
+    return thunkApi.rejectWithValue(err)
+  }
+})

--- a/applications/launchpad/gui-react/src/store/baseNode/types.ts
+++ b/applications/launchpad/gui-react/src/store/baseNode/types.ts
@@ -1,6 +1,21 @@
 import type { Network } from '../../containers/BaseNodeContainer/types'
 
+export interface BaseNodeIdentityDto {
+  publicKey: number[]
+  nodeId: number[]
+  publicAddress: string
+  emojiId: string
+}
+
+export interface BaseNodeIdentity {
+  publicKey: string
+  nodeId: string
+  publicAddress: string
+  emojiId: string
+}
+
 export type BaseNodeState = {
   network: Network
   rootFolder: string
+  identity?: BaseNodeIdentity
 }

--- a/applications/launchpad/gui-react/src/store/mining/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/mining/selectors.ts
@@ -56,8 +56,12 @@ export const selectTariSetupRequired = createSelector(
 export const selectMergedMiningState = (r: RootState) => r.mining.merged
 export const selectMergedMiningAddress = (r: RootState) =>
   r.mining.merged.address
+export const selectMergedMiningThreads = (r: RootState) =>
+  r.mining.merged.threads
 export const selectMoneroUrls = (r: RootState) =>
   (r.mining.merged.urls || []).map(u => u.url).join(',')
+export const selectMergedAuthentication = (r: RootState) =>
+  r.mining.merged.authentication
 
 export const selectMergedContainers = createSelector(
   selectContainerStatusWithStats(Container.Tor),

--- a/applications/launchpad/gui-react/src/store/settings/selectors.ts
+++ b/applications/launchpad/gui-react/src/store/settings/selectors.ts
@@ -1,10 +1,19 @@
 import { RootState } from '../'
-import { selectMoneroUrls } from '../mining/selectors'
+import { createSelector } from '@reduxjs/toolkit'
+import {
+  selectMergedAuthentication,
+  selectMergedMiningAddress,
+  selectMergedMiningThreads,
+  selectMoneroUrls,
+} from '../mining/selectors'
 import {
   selectWallet,
   selectMoneroUsername,
   selectMoneroPassword,
 } from '../credentials/selectors'
+import { selectNetwork, selectRootFolder } from '../baseNode/selectors'
+import { ServiceSettingsState } from './types'
+import { Network } from '../../containers/BaseNodeContainer/types'
 
 const isAuthActive = (auth?: { username?: string; password?: string }) => {
   return Boolean(auth?.username || auth?.password)
@@ -12,16 +21,45 @@ const isAuthActive = (auth?: { username?: string; password?: string }) => {
 
 export const selectSettingsOpen = (state: RootState) => state.settings.open
 export const selectActiveSettings = (state: RootState) => state.settings.which
-export const selectServiceSettings = (state: RootState) => ({
-  ...state.settings.serviceSettings,
-  tariNetwork: state.baseNode.network,
-  numMiningThreads: state.mining.merged.threads,
-  moneroMiningAddress: state.mining.merged.address,
-  monerodUrl: selectMoneroUrls(state),
-  moneroUseAuth: isAuthActive(state.mining.merged.authentication),
-  parole: selectWallet(state),
-  moneroUsername: selectMoneroUsername(state),
-  moneroPassword: selectMoneroPassword(state),
-  rootFolder: state.baseNode.rootFolder,
-  walletPassword: state.settings.serviceSettings.parole,
-})
+export const selectSettingsState = (state: RootState) =>
+  state.settings.serviceSettings
+
+export const selectServiceSettings = createSelector(
+  selectSettingsState,
+  selectNetwork,
+  selectRootFolder,
+  selectWallet,
+  selectMoneroUsername,
+  selectMoneroPassword,
+  selectMergedMiningThreads,
+  selectMoneroUrls,
+  selectMergedMiningAddress,
+  selectMergedAuthentication,
+  (
+    serviceSettings: ServiceSettingsState,
+    network: Network,
+    rootFolder: string,
+    parole: string,
+    moneroUsername: string,
+    moneroPassword: string,
+    threads: number,
+    moneroUrls: string,
+    mergedMiningAddress?: string,
+    mergedAuthentication?: {
+      username?: string | undefined
+      password?: string | undefined
+    },
+  ) => ({
+    ...serviceSettings,
+    tariNetwork: network,
+    numMiningThreads: threads,
+    moneroMiningAddress: mergedMiningAddress,
+    monerodUrl: moneroUrls,
+    moneroUseAuth: isAuthActive(mergedAuthentication),
+    parole,
+    walletPassword: parole,
+    moneroUsername: moneroUsername,
+    moneroPassword: moneroPassword,
+    rootFolder,
+  }),
+)

--- a/applications/launchpad/gui-react/src/store/settings/types.ts
+++ b/applications/launchpad/gui-react/src/store/settings/types.ts
@@ -23,13 +23,15 @@ export interface InitialSettings {
   rootFolder: string
 }
 
+export type ServiceSettingsState = {
+  parole?: string
+  dockerRegistry: string
+  dockerTag: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} & any
+
 export type SettingsState = {
   open: boolean
   which: Settings
-  serviceSettings: {
-    parole?: string
-    dockerRegistry: string
-    dockerTag: string
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } & any
+  serviceSettings: ServiceSettingsState
 }

--- a/applications/launchpad/gui-react/src/store/wallet/walletService.ts
+++ b/applications/launchpad/gui-react/src/store/wallet/walletService.ts
@@ -3,6 +3,8 @@ import { invoke } from '@tauri-apps/api/tauri'
 import { toT } from '../../utils/Format'
 
 export interface WalletIdentityDto {
+  publicKey: string
+  nodeId: string
   publicAddress: string
   emojiId: string
 }

--- a/applications/launchpad/gui-react/src/utils/Format.ts
+++ b/applications/launchpad/gui-react/src/utils/Format.ts
@@ -120,3 +120,34 @@ export const formatAmount = (amount: string | number): string => {
     }
   }
 }
+
+/**
+ * Convert array of U8 into string
+ * (ie. base node's public key)
+ * @param {string} data - array of U8 as a string
+ */
+export const convertU8ToString = (data: string) => {
+  try {
+    if (!data || data === '[]') {
+      return ''
+    }
+    const parsed = data.replace('[', '').replace(']', '').split(',')
+    return parsed.map(c => String.fromCharCode(Number(c))).join('')
+  } catch (_) {
+    return ''
+  }
+}
+
+/**
+ * Convert Bytes array into the Hex (as string)
+ * @param {number[]} bytes - U8 bytes array
+ */
+export const bytesToHex = (bytes: number[]): string => {
+  const hex = []
+  for (let i = 0; i < bytes.length; i++) {
+    const current = bytes[i] < 0 ? bytes[i] + 256 : bytes[i]
+    hex.push((current >>> 4).toString(16))
+    hex.push((current & 0xf).toString(16))
+  }
+  return hex.join('')
+}


### PR DESCRIPTION
Description
---

- [x] compose the Base Node QR URL and render in modal
- [x] fix re-rendering settings container by re-composing the `serviceSettings` selector
- [x] add util converting from bytes array to hex

Motivation and Context
---

#340

How Has This Been Tested?
---

_Example of the QR content:_

```
tari://dibbler/base_nodes/add?name=e5e915c44fcffaa37fd764f587&peer=bc3a3063677589fb0fc1957a77f1fdbbd023aa5fa19f1297e66361cc03a19567::/onion3/cdqxb4njbbvrdsahjtiqa7cb5qhjshlqw7u5huxwu2oja4h4ewxoeuid:18141
```

Compare launchpad's QR code with the QR code from Base Node (docker) container:

Get Launchpad QR Code:

1. Run launchpad
2. go to the Base node tab and start base node
3. click on **Connect your Aurora app** and read the QR code with QR scanner

Get QR code from Base Node (docker) container (start docker containers first: Tor + Base Node)

```
$ docker ps
// Check the id of base node container
$ docker attach <base_node_container_id>

// Click Ctrl + C / Cmd + C to enter the interactive console, and type:
$ whoami

// You should see the QR code, scan it and compare with the QR code from Launchpad
```



![image](https://user-images.githubusercontent.com/11715931/178491610-ca2b840a-71d0-4994-8520-2fd9bc976f7c.png)
