### PR TITLE
feat: base node sync progress in fe

### DIFF
--- a/applications/launchpad/backend/src/api/base_node_api.rs
+++ b/applications/launchpad/backend/src/api/base_node_api.rs
@@ -39,7 +39,7 @@ pub const ONBOARDING_PROGRESS_DESTINATION: &str = "tari://onboarding_progress";
 pub async fn base_node_sync_progress(app: AppHandle<Wry>) -> Result<(), String> {
     info!("Setting up progress info stream");
     let mut client = GrpcBaseNodeClient::new();
-    let mut stream = client.stream().await.unwrap();
+    let mut stream = client.stream().await.map_err(|e| e.chained_message())?;
 
     let app_clone = app.clone();
     tauri::async_runtime::spawn(async move {

--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -31,7 +31,6 @@ use serde::Serialize;
 use tari_app_grpc::tari_rpc::wallet_client;
 use tauri::{http::status, AppHandle, Manager, Wry};
 pub use wallet_api::{wallet_balance, wallet_events, wallet_identity};
-pub use base_node_api::base_node_sync_progress;
 
 use crate::{
     commands::{status, AppState, ServiceSettings, DEFAULT_IMAGES},

--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -31,6 +31,7 @@ use serde::Serialize;
 use tari_app_grpc::tari_rpc::wallet_client;
 use tauri::{http::status, AppHandle, Manager, Wry};
 pub use wallet_api::{wallet_balance, wallet_events, wallet_identity};
+pub use base_node_api::base_node_sync_progress;
 
 use crate::{
     commands::{status, AppState, ServiceSettings, DEFAULT_IMAGES},

--- a/applications/launchpad/backend/src/main.rs
+++ b/applications/launchpad/backend/src/main.rs
@@ -41,7 +41,7 @@ use tauri::{
 use tauri_plugin_sql::{Migration, MigrationKind, TauriSql};
 
 use crate::{
-    api::{image_info, network_list, wallet_balance, wallet_events, wallet_identity},
+    api::{base_node_sync_progress, image_info, network_list, wallet_balance, wallet_events, wallet_identity},
     commands::{
         create_default_workspace,
         create_new_workspace,
@@ -160,7 +160,8 @@ fn main() {
             shutdown,
             wallet_events,
             wallet_balance,
-            wallet_identity
+            wallet_identity,
+            base_node_sync_progress
         ])
         .on_window_event(on_event)
         .run(context)

--- a/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
+++ b/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
@@ -23,31 +23,7 @@ import { TBotMessage, TBotMessageHOCProps } from '../../TBot/TBotPrompt/types'
 import { useTheme } from 'styled-components'
 import { SyncType, useBaseNodeSync } from '../../../useBaseNodeSync'
 import Loading from '../../Loading'
-
-/**
- * Convert from seconds into hours-minutes-seconds
- * @param {number} time - time in seconds
- * @param {string}
- */
-const humanizeTime = (time: number) => {
-  const h = Math.floor(time / 3600)
-  const m = Math.floor((time % 3600) / 60)
-  const s = Math.floor((time % 3600) % 60)
-  let result = ''
-
-  if (h > 0) {
-    result += `${h}h `
-  }
-  if (m > 0) {
-    result += `${m} min `
-  }
-
-  if (m < 3) {
-    result += `${s} s`
-  }
-
-  return result
-}
+import { humanizeEstimatedTime } from '../../../utils/Format'
 
 /**
  * Renders the progress bar and remaining time
@@ -92,7 +68,8 @@ const Progress = ({
             </CalcRemainTimeCont>
           ) : (
             <>
-              {humanizeTime(time)} {t.common.adjectives.remaining.toLowerCase()}
+              {humanizeEstimatedTime(time)}{' '}
+              {t.common.adjectives.remaining.toLowerCase()}
             </>
           )}
         </Text>

--- a/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
+++ b/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
@@ -171,7 +171,7 @@ export const BlockchainSyncStep = ({
     }
   }
 
-  const baseNodeSyncProgress = useBaseNodeSync(syncStarting)
+  const baseNodeSyncProgress = useBaseNodeSync(syncStarted)
 
   useEffect(() => {
     if (syncStarted && updateMessageBoxSize && contentRef.current) {

--- a/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
+++ b/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
@@ -8,8 +8,11 @@ import Button from '../../Button'
 
 import { useAppDispatch } from '../../../store/hooks'
 import { setOnboardingComplete } from '../../../store/app'
-import { actions as baseNodeActions } from '../../../store/baseNode'
+
+import { actions as containersActions } from '../../../store/containers'
 import {
+  CalcRemainTimeCont,
+  CalcRemainTimeContLoader,
   CtaButtonContainer,
   FlexContent,
   ProgressContainer,
@@ -18,12 +21,46 @@ import {
 import ProgressBar from '../../ProgressBar'
 import { TBotMessage, TBotMessageHOCProps } from '../../TBot/TBotPrompt/types'
 import { useTheme } from 'styled-components'
+import { SyncType, useBaseNodeSync } from '../../../useBaseNodeSync'
+import Loading from '../../Loading'
 
 /**
- * @TODO - how the Blockchain synchronization should to work?
+ * Convert from seconds into hours-minutes-seconds
+ * @param {number} time - time in seconds
+ * @param {string}
  */
+const humanizeTime = (time: number) => {
+  const h = Math.floor(time / 3600)
+  const m = Math.floor((time % 3600) / 60)
+  const s = Math.floor((time % 3600) % 60)
+  let result = ''
 
-const Progress = ({ progress, time }: { progress: number; time: string }) => {
+  if (h > 0) {
+    result += `${h}h `
+  }
+  if (m > 0) {
+    result += `${m} min `
+  }
+
+  if (m < 3) {
+    result += `${s} s`
+  }
+
+  return result
+}
+
+/**
+ * Renders the progress bar and remaining time
+ */
+const Progress = ({
+  progress,
+  time,
+  type,
+}: {
+  progress?: number
+  time?: number
+  type?: SyncType
+}) => {
   const theme = useTheme()
 
   return (
@@ -36,18 +73,37 @@ const Progress = ({ progress, time }: { progress: number; time: string }) => {
           marginBottom: theme.spacingVertical(0.5),
         }}
       >
-        {t.onboarding.lastSteps.blockchainIsSyncing}
+        {t.onboarding.lastSteps.blockchainIsSyncing}{' '}
+        {type && type === 'Header' && '(1/2)'}
+        {type && type === 'Block' && '(2/2)'}
       </Text>
-      <ProgressBar value={progress} />
+      <ProgressBar value={progress || 0} />
       <RemainingTime>
         <Text type='smallMedium'>
-          {time} {t.common.adjectives.remaining.toLowerCase()}
+          {time === undefined ? (
+            <CalcRemainTimeCont>
+              <CalcRemainTimeContLoader>
+                <Loading loading size='14px' />
+              </CalcRemainTimeContLoader>
+              <span>
+                {t.common.phrases.calculatingTheRemainingTime}
+                ...
+              </span>
+            </CalcRemainTimeCont>
+          ) : (
+            <>
+              {humanizeTime(time)} {t.common.adjectives.remaining.toLowerCase()}
+            </>
+          )}
         </Text>
       </RemainingTime>
     </ProgressContainer>
   )
 }
 
+/**
+ * Renders the onboarding message running the blockchain sync
+ */
 export const BlockchainSyncStep = ({
   pushMessages,
   updateMessageBoxSize,
@@ -58,9 +114,8 @@ export const BlockchainSyncStep = ({
 
   const contentRef = useRef<HTMLDivElement | null>(null)
 
+  const [syncStarting, setSyncStarting] = useState(false)
   const [syncStarted, setSyncStarted] = useState(false)
-  const [progress, setProgress] = useState(0)
-  const [remainingTime, setRemainingTime] = useState('55 min')
 
   const pushErrorMessage = () => {
     pushMessages([
@@ -86,7 +141,7 @@ export const BlockchainSyncStep = ({
   }
 
   const startSync = async () => {
-    setSyncStarted(true)
+    setSyncStarting(true)
     pushMessages([
       {
         content: <Text>{t.onboarding.lastSteps.message2}</Text>,
@@ -95,11 +150,28 @@ export const BlockchainSyncStep = ({
       },
     ])
     try {
-      await dispatch(baseNodeActions.startNode()).unwrap()
-    } catch (e) {
-      pushErrorMessage()
+      await dispatch(
+        containersActions.startRecipe({ containerName: 'base_node' }),
+      ).unwrap()
+      setSyncStarted(true)
+    } catch (err) {
+      /**
+       * @TODO (#381) on first attempt, it returns :
+       * "Something went wrong with the Docker Wrapper caused by: The designated workspace, default, already exists"
+       * It happens when all containers, local storage and docker volumes are removed before the app launch.
+       */
+      try {
+        await dispatch(
+          containersActions.startRecipe({ containerName: 'base_node' }),
+        ).unwrap()
+        setSyncStarted(true)
+      } catch (err2) {
+        pushErrorMessage()
+      }
     }
   }
+
+  const baseNodeSyncProgress = useBaseNodeSync(syncStarting)
 
   useEffect(() => {
     if (syncStarted && updateMessageBoxSize && contentRef.current) {
@@ -111,32 +183,11 @@ export const BlockchainSyncStep = ({
     dispatch(setOnboardingComplete(true))
   }
 
-  /** MOCK WAITING FOR BASE NODE EVENT ABOUT SYNC PROGRESS */
-  const intervalRef = useRef<ReturnType<typeof setInterval> | undefined>()
-  const [intervalStarted, setIntervalStarted] = useState(false)
   useEffect(() => {
-    if (syncStarted && !intervalStarted) {
-      let counter = 1
-      intervalRef.current = setInterval(async () => {
-        setProgress(counter * 10)
-        setRemainingTime(`${55 - counter * 5} min`)
-        if (counter === 6) {
-          pushErrorMessage()
-        }
-        if (counter > 10) {
-          finishSyncing()
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          clearInterval(intervalRef.current!)
-        }
-        counter++
-      }, 2000)
-      setIntervalStarted(true)
+    if (baseNodeSyncProgress.finished) {
+      finishSyncing()
     }
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return () => clearInterval(intervalRef.current!)
-  }, [syncStarted])
-  /** END OF MOCK WAITING FOR BASE NODE EVENT ABOUT SYNC PROGRESS */
+  }, [baseNodeSyncProgress.finished])
 
   return (
     <FlexContent ref={contentRef}>
@@ -144,7 +195,7 @@ export const BlockchainSyncStep = ({
         {t.onboarding.lastSteps.message1} ✨💪
       </Text>
 
-      {!syncStarted && (
+      {!syncStarting && (
         <CtaButtonContainer>
           <Button variant='primary' onClick={startSync}>
             {t.onboarding.dockerInstall.startSyncBtn}
@@ -152,9 +203,13 @@ export const BlockchainSyncStep = ({
         </CtaButtonContainer>
       )}
 
-      {syncStarted && (
+      {syncStarting && (
         <>
-          <Progress progress={progress} time={remainingTime} />
+          <Progress
+            progress={baseNodeSyncProgress.progress}
+            time={baseNodeSyncProgress.remainingTime}
+            type={baseNodeSyncProgress.syncType}
+          />
           <CtaButtonContainer style={{ justifyContent: 'center' }}>
             <Button variant='secondary' onClick={() => appWindow.close()}>
               {t.common.verbs.cancel}

--- a/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/styles.ts
+++ b/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/styles.ts
@@ -45,3 +45,12 @@ export const RemainingTime = styled.div`
   margin-top: ${({ theme }) => theme.spacingVertical(1.5)};
   margin-bottom: ${({ theme }) => theme.spacingVertical(2)};
 `
+
+export const CalcRemainTimeCont = styled.div`
+  display: flex;
+`
+
+export const CalcRemainTimeContLoader = styled.div`
+  padding-top: ${({ theme }) => theme.spacingVertical(0.18)};
+  margin-right: ${({ theme }) => theme.spacingHorizontal(0.4)};
+`

--- a/applications/launchpad/gui-react/src/locales/common.ts
+++ b/applications/launchpad/gui-react/src/locales/common.ts
@@ -78,7 +78,7 @@ const translations: { [key: string]: { [key: string]: string } } = {
     pleaseWait: 'Please wait',
     yourJobIsDoneHere: 'Your job is done here',
     calculatingTheRemainingTime:
-      'Calculating remaining time (this may take few minutes)',
+      'Calculating remaining time (this may take a few minutes)',
   },
   containers: {
     [Container.Tor]: 'Tor',

--- a/applications/launchpad/gui-react/src/locales/common.ts
+++ b/applications/launchpad/gui-react/src/locales/common.ts
@@ -77,6 +77,8 @@ const translations: { [key: string]: { [key: string]: string } } = {
     gotIt: 'Got it',
     pleaseWait: 'Please wait',
     yourJobIsDoneHere: 'Your job is done here',
+    calculatingTheRemainingTime:
+      'Calculating remaining time (this may take few minutes)',
   },
   containers: {
     [Container.Tor]: 'Tor',

--- a/applications/launchpad/gui-react/src/useBaseNodeSync.ts
+++ b/applications/launchpad/gui-react/src/useBaseNodeSync.ts
@@ -37,6 +37,19 @@ export const useBaseNodeSync = (started: boolean) => {
     syncType: undefined,
   })
 
+  const invokeWithDelay = async () => {
+    /**
+     * @TODO if we do not wait, the backend has an issue base_node_gprc
+     * bc base node is not running yet.
+     * Should this be handled by the backend?
+     * Or frontend can check the status_check/health first?
+     * Because waiting arbirtary 10sec is not a good idea.
+     */
+    await wait(10000)
+
+    invoke('base_node_sync_progress')
+  }
+
   useEffect(() => {
     if (isAlreadyInvoked) {
       return
@@ -45,7 +58,6 @@ export const useBaseNodeSync = (started: boolean) => {
     let unsubscribe
 
     const listenToEvents = async () => {
-      await wait(2000)
       unsubscribe = await listen(
         'tari://onboarding_progress',
         async ({
@@ -84,8 +96,7 @@ export const useBaseNodeSync = (started: boolean) => {
 
     if (started) {
       listenToEvents()
-
-      invoke('base_node_sync_progress')
+      invokeWithDelay()
     }
 
     return unsubscribe

--- a/applications/launchpad/gui-react/src/useBaseNodeSync.ts
+++ b/applications/launchpad/gui-react/src/useBaseNodeSync.ts
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react'
+import { invoke } from '@tauri-apps/api/tauri'
+import { listen } from '@tauri-apps/api/event'
+
+export type SyncType = 'Header' | 'Block'
+
+export type BaseNodeSyncProgress = {
+  elapsed_time_sec: number
+  max_estimated_time_sec: number
+  min_estimated_time_sec: number
+  starting_items_index: number
+  sync_type: SyncType
+  synced_items: number
+  total_items: number
+}
+
+export type SyncProgress = {
+  syncType?: SyncType
+  progress?: number
+  remainingTime?: number
+  finished?: boolean
+}
+
+const wait = (ms: number) => {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+let isAlreadyInvoked = false
+
+/**
+ * Listen to the Base Node sync progress
+ */
+export const useBaseNodeSync = (started: boolean) => {
+  const [progress, setProgress] = useState<SyncProgress>({
+    progress: undefined,
+    remainingTime: undefined,
+    syncType: undefined,
+  })
+
+  useEffect(() => {
+    if (isAlreadyInvoked) {
+      return
+    }
+
+    let unsubscribe
+
+    const listenToEvents = async () => {
+      await wait(2000)
+      unsubscribe = await listen(
+        'tari://onboarding_progress',
+        async ({
+          event: _,
+          payload,
+        }: {
+          event: string
+          payload: BaseNodeSyncProgress
+        }) => {
+          try {
+            setProgress({
+              progress: Math.round(
+                (payload.synced_items / payload.total_items) * 100,
+              ),
+              remainingTime: Math.round(
+                (payload.max_estimated_time_sec +
+                  payload.min_estimated_time_sec) /
+                  2,
+              ),
+              syncType: payload.sync_type,
+              finished: payload.synced_items >= payload.total_items,
+            })
+          } catch (_) {
+            setProgress({
+              progress: undefined,
+              remainingTime: undefined,
+              syncType: undefined,
+              finished: undefined,
+            })
+          }
+        },
+      )
+
+      isAlreadyInvoked = true
+    }
+
+    if (started) {
+      listenToEvents()
+
+      invoke('base_node_sync_progress')
+    }
+
+    return unsubscribe
+  }, [started])
+
+  return progress
+}

--- a/applications/launchpad/gui-react/src/utils/Format.test.ts
+++ b/applications/launchpad/gui-react/src/utils/Format.test.ts
@@ -1,4 +1,10 @@
-import { humanizeTime, toT, toMicroT, formatAmount } from './Format'
+import {
+  humanizeTime,
+  toT,
+  toMicroT,
+  formatAmount,
+  humanizeEstimatedTime,
+} from './Format'
 
 describe('Format', () => {
   it('humanizeTime: should properly convert milliseconds to the readable string', () => {
@@ -57,5 +63,12 @@ describe('Format', () => {
     expect(formatAmount(123123123.789)).toBe(
       (123123123.79).toLocaleString([], { maximumFractionDigits: 2 }),
     )
+  })
+
+  it('formats the estimated time', () => {
+    expect(humanizeEstimatedTime(450)).toBe('7 min')
+    expect(humanizeEstimatedTime(65)).toBe('1 min 5 s')
+    expect(humanizeEstimatedTime(7896)).toBe('2h 11 min')
+    expect(humanizeEstimatedTime(7)).toBe('7 s')
   })
 })

--- a/applications/launchpad/gui-react/src/utils/Format.ts
+++ b/applications/launchpad/gui-react/src/utils/Format.ts
@@ -57,6 +57,36 @@ export const humanizeTime = (time: number): string => {
 }
 
 /**
+ * Convert milliseconds to the "estimated time".
+ * It will display only significant time components: hours, minutes, seconds,
+ * depending on the time value.
+ * For instance, it will display seconds if remaining less than 3 minutes.
+ * @param {time} time - the time in milliseconds
+ *
+ * @example
+ * humanizeEstimatedTime(4500)
+ */
+export const humanizeEstimatedTime = (time: number): string => {
+  const h = Math.floor(time / 3600)
+  const m = Math.floor((time % 3600) / 60)
+  const s = Math.floor((time % 3600) % 60)
+  let result = ''
+
+  if (h > 0) {
+    result += `${h}h `
+  }
+  if (m > 0) {
+    result += `${m} min `
+  }
+
+  if (m < 3) {
+    result += `${s} s`
+  }
+
+  return result.trim()
+}
+
+/**
  * Convert Tauri to micro Tauri (uT) value
  * @param {number} amount amount in Tari
  * @returns {number}


### PR DESCRIPTION
Description
---

- [x] Start listening to the base node sync progress in onboarding

TODO:

- Check if Base node is already synced - #385 
- Wait for the base node: Backend gets an error (grpc related - base node is not running yet) when we invoke listener right after starting the service. For now, frontend waits 10sec before invoking base node progress stream  - #385 

Motivation and Context
---

#319 

How Has This Been Tested?
---

This is rendered before we get first event from the backend:

![image](https://user-images.githubusercontent.com/11715931/177778097-8501689d-e437-4cf5-824d-dc6fd096e54a.png)

