### PR TITLE
feat: min window size

### DIFF
--- a/applications/launchpad/backend/tauri.conf.json
+++ b/applications/launchpad/backend/tauri.conf.json
@@ -75,9 +75,9 @@
       {
         "title": "Tari Launchpad",
         "width": 1200,
-        "minWidth": 700,
+        "minWidth": 1200,
         "height": 800,
-        "minHeight": 400,
+        "minHeight": 796,
         "resizable": true,
         "fullscreen": false,
         "decorations": false,


### PR DESCRIPTION
Description
---

Set Tauri window's `minWidth` and `minHeight` so it doesn't break the UI.

The `minWidth` is set to `1200px` so the Calendar in _"Set up mining hours"_ fits the screen.
The `minHeight` is set to `796px` so the small modal window doesn't get the vertical scrollbar.

Motivation and Context
---

#186 

How Has This Been Tested?
---

![image](https://user-images.githubusercontent.com/11715931/177954923-ca4fec42-440a-4e26-af75-ad9f28c36d32.png)

![image](https://user-images.githubusercontent.com/11715931/177955300-c28c33fa-389a-4455-bead-f68baab8d8bf.png)

