### PR TITLE
feat: show node identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7061,6 +7061,7 @@ dependencies = [
  "derivative",
  "env_logger 0.9.0",
  "futures 0.3.21",
+ "hex",
  "indexmap",
  "lazy_static",
  "log",

--- a/applications/launchpad/backend/Cargo.toml
+++ b/applications/launchpad/backend/Cargo.toml
@@ -41,6 +41,7 @@ tonic = "0.6.2"
 # need to force this version to avoid circular dependency in tauri-plugin-sql deps
 # https://github.com/tkaitchuck/aHash/issues/95#issuecomment-881152315
 indexmap = "~1.6.2"
+hex = "0.4.3"
 
 [dependencies.tauri-plugin-sql]
 git = "https://github.com/tauri-apps/tauri-plugin-sql"

--- a/applications/launchpad/backend/src/api/mod.rs
+++ b/applications/launchpad/backend/src/api/mod.rs
@@ -23,6 +23,7 @@ mod base_node_api;
 mod wallet_api;
 use std::{convert::TryFrom, fmt::format};
 
+pub use base_node_api::{base_node_sync_progress, node_identity};
 use config::Config;
 use futures::StreamExt;
 use log::{debug, error, info, warn};

--- a/applications/launchpad/backend/src/grpc/base_node_grpc_client.rs
+++ b/applications/launchpad/backend/src/grpc/base_node_grpc_client.rs
@@ -39,6 +39,7 @@ use tari_app_grpc::tari_rpc::{
     GetBalanceResponse,
     GetIdentityRequest,
     GetIdentityResponse,
+    NodeIdentity,
     TransactionEvent,
     TransactionEventRequest,
     TransactionEventResponse,
@@ -123,5 +124,12 @@ impl GrpcBaseNodeClient {
             }
         });
         Ok(receiver)
+    }
+
+    pub async fn identity(&mut self) -> Result<NodeIdentity, GrpcError> {
+        let connection = self.try_connect().await?.clone();
+        let request = Empty {};
+        let identity = connection.clone().identify(request).await?;
+        Ok(identity.into_inner())
     }
 }


### PR DESCRIPTION
Description:

feat: #379 
The following properties are read and propagated to the front-end:
	public key
	public address
	node id
	emoji id(public k)

Motivation and Context
We should show identity info for base node as well.

How Has This Been Tested?
Manually.
Base node is started and grpc identify method has been called.
All properties are printed correctly in the console.
