### PR TITLE
feat: improve performance when viewing last 8h and 24h

### DIFF
--- a/applications/launchpad/gui-react/src/components/Select/index.tsx
+++ b/applications/launchpad/gui-react/src/components/Select/index.tsx
@@ -57,7 +57,7 @@ const Select = ({
   return (
     <Listbox value={value} onChange={onChange} disabled={disabled}>
       {({ open }: { open: boolean }) => (
-        <>
+        <div>
           {label && (
             <Label inverted={inverted} style={{ ...styles?.label }}>
               {label}
@@ -97,7 +97,7 @@ const Select = ({
               </Listbox.Option>
             ))}
           </OptionsContainer>
-        </>
+        </div>
       )}
     </Listbox>
   )

--- a/applications/launchpad/gui-react/src/components/Select/types.ts
+++ b/applications/launchpad/gui-react/src/components/Select/types.ts
@@ -14,7 +14,7 @@ export interface SelectInternalProps {
  * @property {string} label - label shown in option
  * @property {string} key - key to be used in react map
  */
-export type Option = {
+export interface Option {
   value: string | number
   label: string
   key: string

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/PerformanceChart/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/PerformanceChart/index.tsx
@@ -5,6 +5,7 @@ import UplotReact from 'uplot-react'
 
 import { chartColors } from '../../../../../styles/styles/colors'
 import IconButton from '../../../../../components/IconButton'
+import Loading from '../../../../../components/Loading'
 import { Dictionary } from '../../../../../types/general'
 import VisibleIcon from '../../../../../styles/Icons/Eye'
 import HiddenIcon from '../../../../../styles/Icons/EyeSlash'
@@ -20,6 +21,7 @@ import {
   Legend,
   LegendItem,
   SeriesColorIndicator,
+  TitleContainer,
 } from './styles'
 
 const PerformanceChart = ({
@@ -32,6 +34,7 @@ const PerformanceChart = ({
   percentage,
   unit,
   onFreeze,
+  loading,
 }: {
   since: Date
   now: Date
@@ -42,6 +45,7 @@ const PerformanceChart = ({
   percentage?: boolean
   unit?: string
   onFreeze: (frozen: boolean) => void
+  loading?: boolean
 }) => {
   const theme = useTheme()
   const unitToDisplay = percentage ? '%' : unit || ''
@@ -275,9 +279,12 @@ const PerformanceChart = ({
 
   return (
     <ChartContainer ref={chartContainerRef}>
-      <Text type='defaultHeavy'>
-        {title} [{unitToDisplay}]
-      </Text>
+      <TitleContainer>
+        <Text type='defaultHeavy'>
+          {title} [{unitToDisplay}]
+        </Text>
+        <Loading loading={loading} size='1em' style={{ marginTop: -2 }} />
+      </TitleContainer>
       <div style={{ position: 'relative' }}>
         <Tooltip
           display={Boolean(tooltipState?.display)}

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/PerformanceChart/styles.ts
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/PerformanceChart/styles.ts
@@ -58,3 +58,10 @@ export const SeriesColorIndicator = styled.div<{ color: string }>`
   border-radius: 2px;
   background-color: ${({ color }) => color};
 `
+
+export const TitleContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  column-gap: ${({ theme }) => theme.spacing(0.5)};
+`

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/PerformanceControls.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/PerformanceControls.tsx
@@ -7,31 +7,40 @@ import FilterIcon from '../../../../styles/Icons/Filter'
 import RefreshRateIcon from '../../../../styles/Icons/RotateRight'
 import t from '../../../../locales'
 
-const renderWindowOptions = [
+export interface TimeWindowOption extends Option {
+  resolution: number
+}
+
+const renderWindowOptions: TimeWindowOption[] = [
   {
     value: 30 * 60 * 1000,
     key: '30m',
     label: t.expertView.performance.renderWindowOptionsLabels.last30m,
+    resolution: 1,
   },
   {
     value: 60 * 60 * 1000,
     key: '1h',
     label: t.expertView.performance.renderWindowOptionsLabels.last1h,
+    resolution: 1,
   },
   {
     value: 2 * 60 * 60 * 1000,
     key: '2h',
     label: t.expertView.performance.renderWindowOptionsLabels.last2h,
+    resolution: 1,
   },
   {
     value: 8 * 60 * 60 * 1000,
     key: '8h',
     label: t.expertView.performance.renderWindowOptionsLabels.last8h,
+    resolution: 60,
   },
   {
     value: 24 * 60 * 60 * 1000,
     key: '24h',
     label: t.expertView.performance.renderWindowOptionsLabels.last24h,
+    resolution: 60,
   },
 ]
 export const defaultRenderWindow = renderWindowOptions[0]
@@ -63,8 +72,8 @@ const PerformanceControls = ({
 }: {
   refreshRate: Option
   onRefreshRateChange: (option: Option) => void
-  timeWindow: Option
-  onTimeWindowChange: (option: Option) => void
+  timeWindow: TimeWindowOption
+  onTimeWindowChange: (option: TimeWindowOption) => void
 }) => {
   const theme = useTheme()
 
@@ -90,7 +99,9 @@ const PerformanceControls = ({
         fullWidth={false}
         value={timeWindow}
         options={renderWindowOptions}
-        onChange={onTimeWindowChange}
+        onChange={(option: Option) =>
+          onTimeWindowChange(option as TimeWindowOption)
+        }
         styles={selectStyleOverrides}
       />
       <Select

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/index.tsx
@@ -39,6 +39,7 @@ const PerformanceContainer = () => {
   )
   const unsubscribeFunctions = useRef<(() => void)[]>()
 
+  const [loadingData, setLoadingData] = useState(false)
   const [timeWindow, setTimeWindow] = useState<Option>(defaultRenderWindow)
   const [refreshRate, setRefreshRate] = useState<Option>(defaultRefreshRate)
   const [now, setNow] = useState(() => {
@@ -86,9 +87,14 @@ const PerformanceContainer = () => {
     }
   }, [since])
 
-  useEffect(() => {
-    const getData = async () => {
-      const data = await statsRepository.getEntries(configuredNetwork, since)
+  const getData = async (timeWindowMs: number) => {
+    const windowStart = new Date(new Date().getTime() - timeWindowMs)
+    setLoadingData(true)
+    try {
+      const data = await statsRepository.getEntries(
+        configuredNetwork,
+        windowStart,
+      )
 
       setData(
         data.map(statsEntry => ({
@@ -99,10 +105,20 @@ const PerformanceContainer = () => {
           service: statsEntry.service,
         })),
       )
+    } finally {
+      setLoadingData(false)
     }
+  }
 
-    getData()
-  }, [timeWindow])
+  useEffect(() => {
+    getData(Number(timeWindow.value))
+  }, [])
+
+  const onTimeWindowChange = (option: Option) => {
+    setTimeWindow(option)
+
+    getData(Number(option.value))
+  }
 
   useEffect(() => {
     const subscribeToAllChannels = async () => {
@@ -154,7 +170,7 @@ const PerformanceContainer = () => {
         refreshRate={refreshRate}
         onRefreshRateChange={option => setRefreshRate(option)}
         timeWindow={timeWindow}
-        onTimeWindowChange={option => setTimeWindow(option)}
+        onTimeWindowChange={onTimeWindowChange}
       />
 
       <PerformanceChart
@@ -166,6 +182,7 @@ const PerformanceContainer = () => {
         width={width}
         percentage
         onFreeze={onFreeze}
+        loading={loadingData}
       />
 
       <PerformanceChart
@@ -177,6 +194,7 @@ const PerformanceContainer = () => {
         width={width}
         unit={t.common.units.mib}
         onFreeze={onFreeze}
+        loading={loadingData}
       />
 
       <PerformanceChart
@@ -188,6 +206,7 @@ const PerformanceContainer = () => {
         width={width}
         unit={t.common.units.kbs}
         onFreeze={onFreeze}
+        loading={loadingData}
       />
     </div>
   )

--- a/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/index.tsx
+++ b/applications/launchpad/gui-react/src/containers/Dashboard/ExpertView/Performance/index.tsx
@@ -14,6 +14,7 @@ import { Option } from '../../../../components/Select/types'
 import PerformanceControls, {
   defaultRenderWindow,
   defaultRefreshRate,
+  TimeWindowOption,
 } from './PerformanceControls'
 import PerformanceChart from './PerformanceChart'
 import { MinimalStatsEntry } from './types'
@@ -40,7 +41,8 @@ const PerformanceContainer = () => {
   const unsubscribeFunctions = useRef<(() => void)[]>()
 
   const [loadingData, setLoadingData] = useState(false)
-  const [timeWindow, setTimeWindow] = useState<Option>(defaultRenderWindow)
+  const [timeWindow, setTimeWindow] =
+    useState<TimeWindowOption>(defaultRenderWindow)
   const [refreshRate, setRefreshRate] = useState<Option>(defaultRefreshRate)
   const [now, setNow] = useState(() => {
     const n = new Date()
@@ -114,7 +116,7 @@ const PerformanceContainer = () => {
     getData(Number(timeWindow.value))
   }, [])
 
-  const onTimeWindowChange = (option: Option) => {
+  const onTimeWindowChange = (option: TimeWindowOption) => {
     setTimeWindow(option)
 
     getData(Number(option.value))
@@ -183,6 +185,7 @@ const PerformanceContainer = () => {
         percentage
         onFreeze={onFreeze}
         loading={loadingData}
+        resolution={timeWindow.resolution}
       />
 
       <PerformanceChart
@@ -195,6 +198,7 @@ const PerformanceContainer = () => {
         unit={t.common.units.mib}
         onFreeze={onFreeze}
         loading={loadingData}
+        resolution={timeWindow.resolution}
       />
 
       <PerformanceChart
@@ -207,6 +211,7 @@ const PerformanceContainer = () => {
         unit={t.common.units.kbs}
         onFreeze={onFreeze}
         loading={loadingData}
+        resolution={timeWindow.resolution}
       />
     </div>
   )

--- a/applications/launchpad/gui-react/src/persistence/statsRepository.ts
+++ b/applications/launchpad/gui-react/src/persistence/statsRepository.ts
@@ -55,13 +55,10 @@ const repositoryFactory: () => StatsRepository = () => {
       ])
     },
     getEntries: async (network, since) => {
-      console.debug('getting endtires')
-      console.time('select')
       const results: Omit<StatsEntry, 'timestampS'>[] = await db.select(
         'SELECT timestamp, service, cpu, memory, upload, download FROM stats WHERE network = $1 AND "timestamp" > $2 ORDER BY "timestamp"',
         [network, since.toISOString()],
       )
-      console.timeEnd('select')
 
       return results.map(r => ({
         ...r,

--- a/applications/launchpad/gui-react/src/persistence/statsRepository.ts
+++ b/applications/launchpad/gui-react/src/persistence/statsRepository.ts
@@ -55,10 +55,13 @@ const repositoryFactory: () => StatsRepository = () => {
       ])
     },
     getEntries: async (network, since) => {
+      console.debug('getting endtires')
+      console.time('select')
       const results: Omit<StatsEntry, 'timestampS'>[] = await db.select(
         'SELECT timestamp, service, cpu, memory, upload, download FROM stats WHERE network = $1 AND "timestamp" > $2 ORDER BY "timestamp"',
         [network, since.toISOString()],
       )
+      console.timeEnd('select')
 
       return results.map(r => ({
         ...r,


### PR DESCRIPTION
Description
---

- [x] fix data getter for performance charts when changing window
- [x] visual fix for dropdowns on PerformanceControls
- [x] display average data per minute when showing data for last 8h and 24h

Motivation and Context
---

#327

How Has This Been Tested?
---

