### PR TITLE
chore: tari console wallet to tari wallet

### DIFF
--- a/applications/launchpad/backend/src/docker/models.rs
+++ b/applications/launchpad/backend/src/docker/models.rs
@@ -210,7 +210,7 @@ impl ImageType {
         match self {
             Self::Tor => "tor",
             Self::BaseNode => "tari_base_node",
-            Self::Wallet => "tari_console_wallet",
+            Self::Wallet => "tari_wallet",
             Self::XmRig => "xmrig",
             Self::Sha3Miner => "tari_sha3_miner",
             Self::MmProxy => "tari_mm_proxy",


### PR DESCRIPTION
Description
---

Change `tari_wallet_console` to `tari_wallet` on backend.

Motivation and Context
---

How Has This Been Tested?
---

Start wallet container
