### PR TITLE
fix: blockchain sync issues

### DIFF
--- a/applications/launchpad/backend/src/api/base_node_api.rs
+++ b/applications/launchpad/backend/src/api/base_node_api.rs
@@ -60,7 +60,7 @@ pub async fn base_node_sync_progress(app: AppHandle<Wry>) -> Result<(), String> 
                             header_progress.start(message.local_height, message.tip_height);
                         }
                     },
-                    SyncType::Block => {
+                    SyncType::Block | SyncType::Done => {
                         if block_progress.started {
                             let progress = SyncProgressInfo::from(block_progress.clone());
                             if let Err(err) = app_clone.emit_all(ONBOARDING_PROGRESS_DESTINATION, progress) {
@@ -69,7 +69,7 @@ pub async fn base_node_sync_progress(app: AppHandle<Wry>) -> Result<(), String> 
                         } else {
                             block_progress.start(message.local_height, message.tip_height);
                         }
-                    },
+                    }
                 }
             }
         }

--- a/applications/launchpad/backend/src/api/base_node_api.rs
+++ b/applications/launchpad/backend/src/api/base_node_api.rs
@@ -24,53 +24,32 @@
 use std::convert::TryFrom;
 
 use futures::StreamExt;
-use log::{error, info, warn};
+use log::*;
 use tauri::{AppHandle, Manager, Wry};
 
 use crate::{
     commands::status,
     docker::ImageType,
-    grpc::{BaseNodeIdentity, GrpcBaseNodeClient, SyncProgress, SyncProgressInfo, SyncType},
+    grpc::{BaseNodeIdentity, GrpcBaseNodeClient},
 };
 
 pub const ONBOARDING_PROGRESS_DESTINATION: &str = "tari://onboarding_progress";
 
+const LOG_TARGET: &str = "tari_launchpad::base_node_api";
+
 #[tauri::command]
 pub async fn base_node_sync_progress(app: AppHandle<Wry>) -> Result<(), String> {
-    info!("Setting up progress info stream");
+    info!(target: LOG_TARGET, "Setting up progress info stream");
     let mut client = GrpcBaseNodeClient::new();
     let mut stream = client.stream().await.map_err(|e| e.chained_message())?;
 
     let app_clone = app.clone();
     tauri::async_runtime::spawn(async move {
-        let block_progress = &mut SyncProgress::new(SyncType::Block, 0, 0);
-        let header_progress = &mut SyncProgress::new(SyncType::Header, 0, 0);
-        info!("Syncing blocks progress is started....");
-        while let Some(message) = stream.next().await {
-            if let Some(sync_type) = message.sync_type {
-                match sync_type {
-                    SyncType::Header => {
-                        if header_progress.started {
-                            header_progress.sync(message.local_height, message.tip_height);
-                            let progress = SyncProgressInfo::from(header_progress.clone());
-                            if let Err(err) = app_clone.emit_all(ONBOARDING_PROGRESS_DESTINATION, progress) {
-                                warn!("Could not emit event to front-end, {:?}", err);
-                            }
-                        } else {
-                            header_progress.start(message.local_height, message.tip_height);
-                        }
-                    },
-                    SyncType::Block | SyncType::Done => {
-                        if block_progress.started {
-                            let progress = SyncProgressInfo::from(block_progress.clone());
-                            if let Err(err) = app_clone.emit_all(ONBOARDING_PROGRESS_DESTINATION, progress) {
-                                warn!("Could not emit event to front-end, {:?}", err);
-                            }
-                        } else {
-                            block_progress.start(message.local_height, message.tip_height);
-                        }
-                    }
-                }
+        info!(target: LOG_TARGET, "Syncing blocks progress is started....");
+        while let Some(progress) = stream.next().await {
+            debug!(target: LOG_TARGET, "Blockchain sync progress: {:?}", progress);
+            if let Err(err) = app_clone.emit_all(ONBOARDING_PROGRESS_DESTINATION, progress) {
+                warn!(target: LOG_TARGET, "Could not emit event to front-end, {:?}", err);
             }
         }
     });
@@ -84,10 +63,14 @@ pub async fn node_identity() -> Result<BaseNodeIdentity, String> {
     if "running" == status.to_lowercase() {
         let mut node_client = GrpcBaseNodeClient::new();
         let identity = node_client.identity().await.map_err(|e| e.to_string())?;
-        info!("SUCCESS: IDENTITY: {:?}", identity);
+        info!(target: LOG_TARGET, "SUCCESS: IDENTITY: {:?}", identity);
         BaseNodeIdentity::try_from(identity)
     } else {
-        error!("Base node container[image = {}] is not running", ImageType::BaseNode);
+        error!(
+            target: LOG_TARGET,
+            "Base node container[image = {}] is not running",
+            ImageType::BaseNode
+        );
         Err("tari_base_node is not running".to_string())
     }
 }

--- a/applications/launchpad/backend/src/grpc/base_node_grpc_client.rs
+++ b/applications/launchpad/backend/src/grpc/base_node_grpc_client.rs
@@ -55,8 +55,10 @@ use super::{error::GrpcError, BlockStateInfo};
 use crate::{
     docker::{DockerWrapperError, LaunchpadConfig, BASE_NODE_GRPC_ADDRESS_URL},
     error::LauncherError,
+    grpc::{SyncProgress, SyncProgressInfo},
 };
 
+const LOG_TARGET: &str = "tari_launchpad::base_node_grpc";
 type Inner = BaseNodeClient<tonic::transport::Channel>;
 
 #[derive(Clone)]
@@ -83,40 +85,48 @@ impl GrpcBaseNodeClient {
         loop {
             match self.try_connect().await {
                 Ok(_) => {
-                    info!("#### Connected....");
+                    info!(target: LOG_TARGET, "#### Connected....");
                     break;
                 },
                 Err(_) => {
                     sleep(Duration::from_secs(3)).await;
-                    info!("---> Waiting for base node....");
+                    info!(target: LOG_TARGET, "---> Waiting for base node....");
                 },
             }
         }
     }
 
-    pub async fn stream(&mut self) -> Result<impl Stream<Item = BlockStateInfo>, GrpcError> {
+    pub async fn stream(&mut self) -> Result<impl Stream<Item = SyncProgressInfo>, GrpcError> {
         let (mut sender, receiver) = mpsc::channel(100);
         let connection = self.try_connect().await?.clone();
         task::spawn(async move {
+            let mut progress = SyncProgress::new(0, 100);
             loop {
                 let request = Empty {};
                 let response = match connection.clone().get_sync_progress(request).await {
                     Ok(response) => response.into_inner(),
                     Err(status) => {
-                        error!("Failed reading progress from base node: {}", status);
+                        error!(target: LOG_TARGET, "Failed reading progress from base node: {}", status);
                         return;
                     },
                 };
-                let done = matches!(response.state() , tari_app_grpc::tari_rpc::SyncState::Done);
-                debug!("Response: {:?}", response);
-                    sender.try_send(BlockStateInfo::from(response)).unwrap();
+                let done = matches!(response.state(), tari_app_grpc::tari_rpc::SyncState::Done);
+                debug!(target: LOG_TARGET, "Response: {:?}", response);
+                progress.update(response);
+                if let Err(err) = sender.try_send(progress.progress_info()) {
+                    warn!(
+                        target: LOG_TARGET,
+                        "Could not send progress to tokio_stream. {}",
+                        err.to_string()
+                    );
+                }
                 if done {
-                    info!("Blockchain has synced.");
+                    info!(target: LOG_TARGET, "Blockchain has synced.");
                     break;
                 }
                 sleep(Duration::from_secs(10)).await;
             }
-            info!("Closing blockchain sync stream.");
+            info!(target: LOG_TARGET, "Closing blockchain sync stream.");
         });
         Ok(receiver)
     }

--- a/applications/launchpad/backend/src/grpc/model.rs
+++ b/applications/launchpad/backend/src/grpc/model.rs
@@ -34,8 +34,6 @@ use tari_app_grpc::tari_rpc::{
 };
 use tari_common_types::{emoji::EmojiId, types::PublicKey};
 
-pub const BLOCKS_SYNC_EXPECTED_TIME_SEC: u64 = 7200;
-pub const HEADERS_SYNC_EXPECTED_TIME_SEC: u64 = 1800;
 pub const HEADER: i32 = 2;
 pub const BLOCK: i32 = 4;
 pub const DONE: i32 = 5;
@@ -105,32 +103,9 @@ pub struct BlockStateInfo {
     pub sync_type: Option<SyncType>,
 }
 
-#[derive(Serialize, Clone, Debug)]
-pub struct SyncProgressInfo {
-    pub sync_type: SyncType,
-    pub starting_items_index: u64,
-    pub synced_items: u64,
-    pub total_items: u64,
-    pub elapsed_time_sec: u64,
-    pub min_estimated_time_sec: u64,
-    pub max_estimated_time_sec: u64,
-}
-
-#[derive(Debug, Clone)]
-pub struct SyncProgress {
-    pub sync_type: SyncType,
-    pub start_time: Instant,
-    pub started: bool,
-    pub start_index: u64,
-    pub total_items: u64,
-    pub sync_items: u64,
-    pub new_items: u64,
-    pub min_remaining_time: u64,
-    pub max_remaining_time: u64,
-}
-
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub enum SyncType {
+    Startup,
     Block,
     Header,
     Done,
@@ -221,97 +196,6 @@ impl From<GetBalanceResponse> for WalletBalance {
             available_balance: value.available_balance,
             pending_incoming_balance: value.pending_incoming_balance,
             pending_outgoing_balance: value.pending_outgoing_balance,
-        }
-    }
-}
-
-impl SyncProgress {
-    pub fn new(sync_type: SyncType, local_height: u64, tip_height: u64) -> Self {
-        SyncProgress {
-            sync_type,
-            started: false,
-            start_index: local_height,
-            total_items: tip_height,
-            start_time: Instant::now(),
-            sync_items: 0,
-            max_remaining_time: 7200,
-            min_remaining_time: 0,
-            new_items: 0,
-        }
-    }
-
-    pub fn sync_local_items(&mut self, local_height: u64) {
-        self.sync_items = local_height;
-    }
-
-    pub fn sync_total_items(&mut self, tip_height: u64) {
-        self.new_items = tip_height - self.total_items;
-    }
-
-    /// Init and start progress tracking blocks syncing.
-    pub fn start(&mut self, local_height: u64, tip_height: u64) {
-        self.start_index = local_height;
-        self.sync_items = local_height;
-        self.total_items = tip_height;
-        self.start_time = Instant::now();
-        self.started = true;
-    }
-
-    /// Update sync_items and cacludate remaing times.
-    pub fn sync(&mut self, local_height: u64, tip_height: u64) {
-        self.sync_items = local_height;
-        self.total_items = tip_height;
-        self.calucate_estimated_times();
-    }
-
-    /// Calculates max_remaining_time and min_remaining_time based on progress rate.
-    pub fn calucate_estimated_times(&mut self) {
-        let expected_time_in_sec = match self.sync_type {
-            SyncType::Block => BLOCKS_SYNC_EXPECTED_TIME_SEC,
-            SyncType::Header => HEADERS_SYNC_EXPECTED_TIME_SEC,
-            SyncType::Done => 0,
-        } as f32;
-        let elapsed_time_in_sec = self.start_time.elapsed().as_secs_f32();
-        let current_progress = self.calculate_progress_rate();
-        self.min_remaining_time = (elapsed_time_in_sec * (100.0 - current_progress) / current_progress) as u64;
-        let remaining_parts: f32 = (100.0 - current_progress as f32) / 100.0;
-        self.max_remaining_time = (expected_time_in_sec * remaining_parts) as u64;
-    }
-
-    fn calculate_progress_rate(&self) -> f32 {
-        let all_items = (self.total_items - self.start_index) as f32;
-        let all_local_items = (self.sync_items - self.start_index) as f32;
-        (all_local_items * 100.0) / (all_items)
-    }
-}
-
-impl SyncProgressInfo {
-    fn new(sync_type: SyncType, synced_items: u64, total_items: u64) -> Self {
-        SyncProgressInfo {
-            sync_type: sync_type.clone(),
-            starting_items_index: synced_items,
-            synced_items,
-            total_items,
-            elapsed_time_sec: 0,
-            min_estimated_time_sec: 0,
-            max_estimated_time_sec: match sync_type {
-                SyncType::Header => HEADERS_SYNC_EXPECTED_TIME_SEC,
-                _ => BLOCKS_SYNC_EXPECTED_TIME_SEC,
-            },
-        }
-    }
-}
-
-impl From<SyncProgress> for SyncProgressInfo {
-    fn from(source: SyncProgress) -> Self {
-        SyncProgressInfo {
-            sync_type: source.sync_type,
-            starting_items_index: source.start_index,
-            synced_items: source.sync_items,
-            total_items: source.total_items,
-            elapsed_time_sec: source.start_time.elapsed().as_secs(),
-            max_estimated_time_sec: source.max_remaining_time,
-            min_estimated_time_sec: source.min_remaining_time,
         }
     }
 }

--- a/applications/launchpad/backend/src/grpc/model.rs
+++ b/applications/launchpad/backend/src/grpc/model.rs
@@ -38,6 +38,7 @@ pub const BLOCKS_SYNC_EXPECTED_TIME_SEC: u64 = 7200;
 pub const HEADERS_SYNC_EXPECTED_TIME_SEC: u64 = 1800;
 pub const HEADER: i32 = 2;
 pub const BLOCK: i32 = 4;
+pub const DONE: i32 = 5;
 
 pub const STANDARD_MIMBLEWIMBLE: i32 = 0;
 pub const ONE_SIDED: i32 = 1;
@@ -132,6 +133,7 @@ pub struct SyncProgress {
 pub enum SyncType {
     Block,
     Header,
+    Done,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -169,12 +171,11 @@ impl From<SyncProgressResponse> for BlockStateInfo {
         BlockStateInfo {
             tip_height: value.tip_height,
             local_height: value.local_height,
-            sync_type: if value.state == HEADER as i32 {
-                Some(SyncType::Header)
-            } else if value.state == BLOCK as i32 {
-                Some(SyncType::Block)
-            } else {
-                None
+            sync_type: match value.state as i32 {
+                HEADER => Some(SyncType::Header),
+                BLOCK => Some(SyncType::Block),
+                DONE => Some(SyncType::Done),
+                _ => None,
             },
         }
     }
@@ -268,6 +269,7 @@ impl SyncProgress {
         let expected_time_in_sec = match self.sync_type {
             SyncType::Block => BLOCKS_SYNC_EXPECTED_TIME_SEC,
             SyncType::Header => HEADERS_SYNC_EXPECTED_TIME_SEC,
+            SyncType::Done => 0,
         } as f32;
         let elapsed_time_in_sec = self.start_time.elapsed().as_secs_f32();
         let current_progress = self.calculate_progress_rate();

--- a/applications/launchpad/backend/src/grpc/model.rs
+++ b/applications/launchpad/backend/src/grpc/model.rs
@@ -103,7 +103,7 @@ pub struct BlockStateInfo {
     pub sync_type: Option<SyncType>,
 }
 
-#[derive(Debug, Clone, Serialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum SyncType {
     Startup,
     Block,

--- a/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
+++ b/applications/launchpad/gui-react/src/components/Onboarding/OnboardingMessages/LastStepsMessages.tsx
@@ -56,7 +56,7 @@ const Progress = ({
       <ProgressBar value={progress || 0} />
       <RemainingTime>
         <Text type='smallMedium'>
-          {time === undefined ? (
+          {time === undefined || type === 'Startup' ? (
             <CalcRemainTimeCont>
               <CalcRemainTimeContLoader>
                 <Loading loading size='14px' />

--- a/applications/launchpad/gui-react/src/useBaseNodeSync.ts
+++ b/applications/launchpad/gui-react/src/useBaseNodeSync.ts
@@ -2,16 +2,15 @@ import { useEffect, useState } from 'react'
 import { invoke } from '@tauri-apps/api/tauri'
 import { listen } from '@tauri-apps/api/event'
 
-export type SyncType = 'Header' | 'Block'
+export type SyncType = 'Startup' | 'Header' | 'Block'
 
 export type BaseNodeSyncProgress = {
-  elapsed_time_sec: number
-  max_estimated_time_sec: number
-  min_estimated_time_sec: number
-  starting_items_index: number
-  sync_type: SyncType
-  synced_items: number
-  total_items: number
+  estimatedTimeSec: number
+  syncType: SyncType
+  headerProgress: number
+  blockProgress: number
+  totalBlocks: number
+  done: boolean
 }
 
 export type SyncProgress = {
@@ -69,16 +68,13 @@ export const useBaseNodeSync = (started: boolean) => {
         }) => {
           try {
             setProgress({
-              progress: Math.round(
-                (payload.synced_items / payload.total_items) * 100,
-              ),
-              remainingTime: Math.round(
-                (payload.max_estimated_time_sec +
-                  payload.min_estimated_time_sec) /
-                  2,
-              ),
-              syncType: payload.sync_type,
-              finished: payload.synced_items >= payload.total_items,
+              progress:
+                payload.syncType === 'Block'
+                  ? payload.blockProgress
+                  : payload.headerProgress,
+              remainingTime: payload.estimatedTimeSec,
+              syncType: payload.syncType,
+              finished: payload.done,
             })
           } catch (_) {
             setProgress({


### PR DESCRIPTION
closes #385
closes #386

Several edge cases and issues were resolved:
* block sync progress not updating
* handle edge cases where sync state reverts back a step or two

Also: 
* DRY up several instances of essentially copying over unused intermediate
structs.
* Clean up main command loop.
* Syncing with front-end devs, refactor returns JSON object to eliminate
calculations on their side.
* Add STARTUP state so front-end can know when downloading actually
begins.
* Add `done` field that indicates that chain is fully synced.

Example of response (this will get camelCase renamed into a JSON object):
```
 SyncProgressInfo { sync_type: Block, header_progress: 100, block_progress: 68, total_blocks: 79871, estimated_time_sec: 319, done: false }
...
SyncProgressInfo { sync_type: Block, header_progress: 100, block_progress: 99, total_blocks: 79871, estimated_time_sec: 261, done: false }
...
SyncProgressInfo { sync_type: Done, header_progress: 100, block_progress: 100, total_blocks: 79871, estimated_time_sec: 0, done: true }
```
